### PR TITLE
refactor(PhotoViewer): split into hooks, utils, and sub-components

### DIFF
--- a/src/components/photo-viewer/PhotoViewer.tsx
+++ b/src/components/photo-viewer/PhotoViewer.tsx
@@ -1,39 +1,21 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Navigation from './Navigation';
-import ImageOverlay from './ImageOverlay';
+import PhotoViewerImage from './PhotoViewerImage';
+import type { PhotoViewerSettings } from './types';
 import { ZZImage } from '../../types/image.type';
 import { downloadImage } from '../../utils/downloadImage';
+import { EMPTY_PHOTO_VIEWER_SETTINGS } from '../../utils/photo-viewer/constants';
+import { useClickOutsideToClose } from '../../hooks/photo-viewer/useClickOutsideToClose';
+import { useImageNavigation } from '../../hooks/photo-viewer/useImageNavigation';
+import { useImagePreloader } from '../../hooks/photo-viewer/useImagePreloader';
+import { useKeyboardShortcuts } from '../../hooks/photo-viewer/useKeyboardShortcuts';
+import { useMouseDrag } from '../../hooks/photo-viewer/useMouseDrag';
+import { usePhotoViewerSettings } from '../../hooks/photo-viewer/usePhotoViewerSettings';
+import { useTouchGestures } from '../../hooks/photo-viewer/useTouchGestures';
+import { useTransform } from '../../hooks/photo-viewer/useTransform';
+import { useWheelZoom } from '../../hooks/photo-viewer/useWheelZoom';
 
-const DEFAULT_ZOOM_STEP = 0.3;
-const DEFAULT_LARGE_ZOOM = 4;
-
-type PhotoViewerSettings = {
-  allowZoom: boolean;
-  allowRotate: boolean;
-  allowReset: boolean;
-  allowDownload: boolean;
-  doubleClickZoom: number;
-  clickOutsideToExit: boolean;
-  keyboardInteraction: boolean;
-  maxZoom: number;
-  minZoom: number;
-  zoomStep: number;
-  showOverlayByDefault?: boolean;
-  showOverlayButton?: boolean;
-};
-
-const defaultSettings: PhotoViewerSettings = {
-  allowZoom: true,
-  allowRotate: true,
-  allowReset: true,
-  allowDownload: false,
-  doubleClickZoom: DEFAULT_LARGE_ZOOM,
-  clickOutsideToExit: true,
-  keyboardInteraction: true,
-  maxZoom: 4,
-  minZoom: 0.5,
-  zoomStep: DEFAULT_ZOOM_STEP,
-};
+export type { PhotoViewerSettings } from './types';
 
 export type PhotoViewerProps = {
   selectedImage: ZZImage | null;
@@ -43,14 +25,42 @@ export type PhotoViewerProps = {
   settings?: Partial<PhotoViewerSettings>;
 };
 
+const backdropStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.9)',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+};
+
+const imageContainerBaseStyle: React.CSSProperties = {
+  position: 'relative',
+  width: '100%',
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
+  touchAction: 'none',
+};
+
+const keyframesStyle = (
+  <style>{`@keyframes pulse { 0% { opacity: 0.6; } 50% { opacity: 0.8; } 100% { opacity: 0.6; } }`}</style>
+);
+
 export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   selectedImage,
   images,
   onClose,
   onImageChange,
-  settings = {},
+  settings = EMPTY_PHOTO_VIEWER_SETTINGS,
 }) => {
-  const mergedSettings = { ...defaultSettings, ...settings };
   const {
     allowZoom,
     allowRotate,
@@ -64,456 +74,153 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     zoomStep,
     showOverlayByDefault = false,
     showOverlayButton = false,
-  } = mergedSettings;
+  } = usePhotoViewerSettings(settings);
 
-  const [zoom, setZoom] = useState(1);
-  const [rotationCount, setRotationCount] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
-  const [showOverlay, setShowOverlay] = useState(() => showOverlayByDefault && !!selectedImage?.svgOverlay);
-  const [panX, setPanX] = useState(0);
-  const [panY, setPanY] = useState(0);
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
-  const [isLoading, setIsLoading] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
-  const imageRef = useRef<HTMLImageElement>(null);
   const imageContainerRef = useRef<HTMLDivElement>(null);
-  const [currentSelectedImage, setCurrentSelectedImage] = useState<ZZImage | null>(selectedImage);
+  const imageRef = useRef<HTMLImageElement>(null);
 
-  // Touch gesture state
-  const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
-  const lastTouchDistanceRef = useRef<number | null>(null);
-  const initialZoomRef = useRef<number>(1);
-  const touchPanStartRef = useRef<{ x: number; y: number } | null>(null);
-  const isPinchingRef = useRef<boolean>(false);
+  const transform = useTransform({ minZoom, maxZoom });
+  const { zoom, panX, panY, rotationCount, setZoom, setPan, zoomTo, rotate, reset: resetTransform } = transform;
+
+  const { currentImage, next, previous } = useImageNavigation({
+    initialImage: selectedImage,
+    images,
+    onImageChange,
+  });
+
+  const [isHovered, setIsHovered] = useState(false);
+  const [showOverlay, setShowOverlay] = useState(
+    () => showOverlayByDefault && !!selectedImage?.svgOverlay
+  );
 
   useEffect(() => {
-    setCurrentSelectedImage(selectedImage);
-    setZoom(1);
-    setRotationCount(0);
     setShowOverlay(showOverlayByDefault && !!selectedImage?.svgOverlay);
-    setPanX(0);
-    setPanY(0);
-    setIsLoading(true);
-    // Reset touch state
-    touchStartRef.current = null;
-    lastTouchDistanceRef.current = null;
-    touchPanStartRef.current = null;
-    isPinchingRef.current = false;
   }, [selectedImage, showOverlayByDefault]);
 
-  const handleNext = useCallback(() => {
-    const currentImageIndex = images.findIndex(img => img.id === currentSelectedImage?.id);
+  const currentImageId = currentImage?.id;
+  const currentHasOverlay = !!currentImage?.svgOverlay;
+  useEffect(() => {
+    resetTransform();
+    setShowOverlay(prev => (currentHasOverlay ? prev : false));
+  }, [currentImageId, currentHasOverlay, resetTransform]);
 
-    if (images.length > 0) {
-      const nextIndex = (currentImageIndex + 1) % images.length;
-      const nextImage = images[nextIndex];
-      setCurrentSelectedImage(nextImage);
-      setZoom(1);
-      setRotationCount(0);
-      setShowOverlay(prev => (nextImage.svgOverlay ? prev : false));
-      setPanX(0);
-      setPanY(0);
-      setIsLoading(true);
-      onImageChange?.(nextImage);
-    }
-  }, [images, currentSelectedImage, onImageChange]);
+  useImagePreloader({ currentImage, images });
 
-  const handlePrevious = useCallback(() => {
-    const currentImageIndex = images.findIndex(img => img.id === currentSelectedImage?.id);
-    if (images.length > 0) {
-      const prevIndex = (currentImageIndex - 1 + images.length) % images.length;
-      const prevImage = images[prevIndex];
-      setCurrentSelectedImage(prevImage);
-      setZoom(1);
-      setRotationCount(0);
-      setShowOverlay(prev => (prevImage.svgOverlay ? prev : false));
-      setPanX(0);
-      setPanY(0);
-      setIsLoading(true);
-      onImageChange?.(prevImage);
-    }
-  }, [images, currentSelectedImage, onImageChange]);
+  const handleZoomIn = useCallback(() => setZoom(zoom + zoomStep), [setZoom, zoom, zoomStep]);
+  const handleZoomOut = useCallback(() => setZoom(zoom - zoomStep), [setZoom, zoom, zoomStep]);
 
-  const handleZoom = useCallback(
-    (newZoom: number) => {
-      const clampedZoom = Math.min(Math.max(newZoom, minZoom), maxZoom);
-      setZoom(clampedZoom);
-      // Reset pan when zooming back to 1
-      if (clampedZoom === 1) {
-        setPanX(0);
-        setPanY(0);
-      }
-    },
-    [maxZoom, minZoom]
-  );
+  const handleDoubleClick = useCallback(() => {
+    if (!allowZoom) return;
+    setZoom(zoom === doubleClickZoom ? 1 : doubleClickZoom);
+  }, [allowZoom, doubleClickZoom, setZoom, zoom]);
 
   const handleRotate = useCallback(
     (direction: 'left' | 'right' = 'right') => {
-      if (allowRotate) {
-        setRotationCount(prev => prev + (direction === 'left' ? -1 : 1));
-      }
+      if (allowRotate) rotate(direction);
     },
-    [allowRotate]
+    [allowRotate, rotate]
   );
 
   const handleReset = useCallback(() => {
-    if (allowReset) {
-      setZoom(1);
-      setRotationCount(0);
-      setPanX(0);
-      setPanY(0);
-    }
-  }, [allowReset]);
+    if (allowReset) resetTransform();
+  }, [allowReset, resetTransform]);
 
   const handleDownload = useCallback(async () => {
-    if (!allowDownload || !currentSelectedImage) return;
+    if (!allowDownload || !currentImage) return;
+    const filename = currentImage.title || currentImage.alt || 'image';
+    await downloadImage(currentImage.src, filename, imageRef.current);
+  }, [allowDownload, currentImage]);
 
-    const filename = currentSelectedImage.title || currentSelectedImage.alt || 'image';
-    await downloadImage(currentSelectedImage.src, filename, imageRef.current);
-  }, [allowDownload, currentSelectedImage]);
+  const { isDragging, onMouseDown } = useMouseDrag({
+    enabled: zoom > 1,
+    panX,
+    panY,
+    onPan: setPan,
+  });
 
-  const handleDoubleClick = useCallback(() => {
-    if (allowZoom) {
-      handleZoom(zoom === doubleClickZoom ? 1 : doubleClickZoom);
-    }
-  }, [allowZoom, doubleClickZoom, handleZoom, zoom]);
+  const { onTouchStart, onTouchMove, onTouchEnd, reset: resetTouchGestures } = useTouchGestures({
+    allowZoom,
+    zoom,
+    panX,
+    panY,
+    minZoom,
+    maxZoom,
+    imagesCount: images.length,
+    imageContainerRef,
+    onZoomTo: zoomTo,
+    onPan: setPan,
+    onNext: next,
+    onPrevious: previous,
+  });
 
-  const handleWheel = useCallback(
-    (e: WheelEvent) => {
-      if (!allowZoom) return;
-      e.preventDefault();
+  useEffect(() => {
+    resetTouchGestures();
+  }, [currentImageId, resetTouchGestures]);
 
-      const container = containerRef.current;
-      const imageContainer = imageContainerRef.current;
-      if (!container || !imageContainer) return;
+  useWheelZoom({
+    enabled: allowZoom,
+    containerRef,
+    imageContainerRef,
+    zoom,
+    panX,
+    panY,
+    zoomStep,
+    minZoom,
+    maxZoom,
+    onZoomTo: zoomTo,
+  });
 
-      const delta = e.deltaY > 0 ? -zoomStep : zoomStep;
-      const newZoom = Math.min(Math.max(zoom + delta, minZoom), maxZoom);
-
-      // Calculate mouse position relative to container center
-      const containerRect = imageContainer.getBoundingClientRect();
-      const containerCenterX = containerRect.left + containerRect.width / 2;
-      const containerCenterY = containerRect.top + containerRect.height / 2;
-
-      const mouseX = e.clientX - containerCenterX;
-      const mouseY = e.clientY - containerCenterY;
-
-      // Calculate the point on the image (before zoom change)
-      // Account for current pan and zoom
-      const imageX = (mouseX - panX) / zoom;
-      const imageY = (mouseY - panY) / zoom;
-
-      // Calculate new pan to keep the same point under the mouse after zoom
-      const newPanX = mouseX - imageX * newZoom;
-      const newPanY = mouseY - imageY * newZoom;
-
-      setZoom(newZoom);
-      // Reset pan when zooming back to 1
-      if (newZoom === 1) {
-        setPanX(0);
-        setPanY(0);
-      } else {
-        setPanX(newPanX);
-        setPanY(newPanY);
-      }
+  useKeyboardShortcuts({
+    enabled: keyboardInteraction,
+    handlers: {
+      onClose,
+      onZoomIn: handleZoomIn,
+      onZoomOut: handleZoomOut,
+      onRotate: () => handleRotate(),
+      onReset: handleReset,
+      onNext: next,
+      onPrevious: previous,
     },
-    [allowZoom, zoom, zoomStep, minZoom, maxZoom, panX, panY]
-  );
+  });
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (!keyboardInteraction) return;
-      switch (e.key) {
-        case 'Escape':
-          onClose();
-          break;
-        case '+':
-        case '=':
-          handleZoom(zoom + zoomStep);
-          break;
-        case '-':
-          handleZoom(zoom - zoomStep);
-          break;
-        case 'r':
-          handleRotate();
-          break;
-        case '0':
-          handleReset();
-          break;
-        case 'ArrowRight':
-          handleNext();
-          break;
-        case 'ArrowLeft':
-          handlePrevious();
-          break;
-      }
-    },
-    [handleZoom, handleRotate, handleReset, handleNext, handlePrevious, keyboardInteraction, onClose, zoom, zoomStep]
-  );
+  useClickOutsideToClose({ enabled: clickOutsideToExit, onClose });
 
-  const handleClickOutside = useCallback(
-    (e: MouseEvent) => {
-      if (
-        clickOutsideToExit &&
-        containerRef.current &&
-        !(e.target as HTMLElement).closest('.photo-viewer img') &&
-        !(e.target as HTMLElement).closest('.photo-viewer-navigation') &&
-        !(e.target as HTMLElement).closest('.nav-action-button')
-      ) {
-        onClose();
-      }
-    },
-    [clickOutsideToExit, onClose]
-  );
+  if (!selectedImage || !currentImage) return null;
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      // Only allow panning when zoomed in, and only on left mouse button
-      if (zoom > 1 && e.button === 0) {
-        e.preventDefault();
-        setIsDragging(true);
-        setDragStart({ x: e.clientX - panX, y: e.clientY - panY });
-      }
-    },
-    [zoom, panX, panY]
-  );
-
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent | MouseEvent) => {
-      if (isDragging && zoom > 1) {
-        e.preventDefault();
-        const newPanX = e.clientX - dragStart.x;
-        const newPanY = e.clientY - dragStart.y;
-        setPanX(newPanX);
-        setPanY(newPanY);
-      }
-    },
-    [isDragging, zoom, dragStart]
-  );
-
-  const handleMouseUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  // Calculate distance between two touches
-  const getTouchDistance = (touch1: React.Touch | Touch, touch2: React.Touch | Touch): number => {
-    const dx = touch1.clientX - touch2.clientX;
-    const dy = touch1.clientY - touch2.clientY;
-    return Math.sqrt(dx * dx + dy * dy);
+  const imageContainerStyle: React.CSSProperties = {
+    ...imageContainerBaseStyle,
+    cursor: zoom > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default',
   };
 
-  const handleTouchStart = useCallback(
-    (e: React.TouchEvent) => {
-      if (!allowZoom && !images.length) return;
-
-      const touches = e.touches;
-
-      if (touches.length === 1) {
-        // Single touch - prepare for swipe or pan
-        const touch = touches[0];
-        touchStartRef.current = {
-          x: touch.clientX,
-          y: touch.clientY,
-          time: Date.now(),
-        };
-
-        if (zoom > 1) {
-          // Prepare for pan
-          touchPanStartRef.current = { x: touch.clientX - panX, y: touch.clientY - panY };
-        }
-      } else if (touches.length === 2 && allowZoom) {
-        // Two touches - prepare for pinch zoom
-        e.preventDefault();
-        isPinchingRef.current = true;
-        lastTouchDistanceRef.current = getTouchDistance(touches[0], touches[1]);
-        initialZoomRef.current = zoom;
-      }
-    },
-    [allowZoom, zoom, panX, panY, images.length]
-  );
-
-  const handleTouchMove = useCallback(
-    (e: React.TouchEvent) => {
-      const touches = e.touches;
-      const imageContainer = imageContainerRef.current;
-      if (!imageContainer) return;
-
-      if (touches.length === 2 && allowZoom && isPinchingRef.current) {
-        // Pinch zoom
-        e.preventDefault();
-        const distance = getTouchDistance(touches[0], touches[1]);
-
-        if (lastTouchDistanceRef.current !== null) {
-          const scale = distance / lastTouchDistanceRef.current;
-          const newZoom = Math.min(Math.max(zoom * scale, minZoom), maxZoom);
-
-          // Calculate center point between the two touches
-          const centerX = (touches[0].clientX + touches[1].clientX) / 2;
-          const centerY = (touches[0].clientY + touches[1].clientY) / 2;
-
-          const containerRect = imageContainer.getBoundingClientRect();
-          const containerCenterX = containerRect.left + containerRect.width / 2;
-          const containerCenterY = containerRect.top + containerRect.height / 2;
-
-          const mouseX = centerX - containerCenterX;
-          const mouseY = centerY - containerCenterY;
-
-          const imageX = (mouseX - panX) / zoom;
-          const imageY = (mouseY - panY) / zoom;
-
-          const newPanX = mouseX - imageX * newZoom;
-          const newPanY = mouseY - imageY * newZoom;
-
-          setZoom(newZoom);
-          if (newZoom === 1) {
-            setPanX(0);
-            setPanY(0);
-          } else {
-            setPanX(newPanX);
-            setPanY(newPanY);
-          }
-
-          // Update distance for next move
-          lastTouchDistanceRef.current = distance;
-        }
-      } else if (touches.length === 1 && zoom > 1 && touchPanStartRef.current) {
-        // Single touch pan when zoomed
-        e.preventDefault();
-        const touch = touches[0];
-        const newPanX = touch.clientX - touchPanStartRef.current.x;
-        const newPanY = touch.clientY - touchPanStartRef.current.y;
-        setPanX(newPanX);
-        setPanY(newPanY);
-      }
-    },
-    [allowZoom, zoom, minZoom, maxZoom, panX, panY]
-  );
-
-  const handleTouchEnd = useCallback(
-    (e: React.TouchEvent) => {
-      const touches = e.touches;
-
-      if (touches.length === 0 || touches.length === 1) {
-        // All fingers lifted or only one remaining
-        if (isPinchingRef.current) {
-          isPinchingRef.current = false;
-          lastTouchDistanceRef.current = null;
-          return;
-        }
-
-        if (touchStartRef.current && zoom === 1 && images.length > 1) {
-          // Check for swipe gesture
-          const touch = e.changedTouches[0];
-          const deltaX = touch.clientX - touchStartRef.current.x;
-          const deltaY = touch.clientY - touchStartRef.current.y;
-          const deltaTime = Date.now() - touchStartRef.current.time;
-
-          // Swipe threshold: at least 50px horizontal movement, less than 300ms, and more horizontal than vertical
-          const minSwipeDistance = 50;
-          const maxSwipeTime = 300;
-
-          if (Math.abs(deltaX) > minSwipeDistance && Math.abs(deltaX) > Math.abs(deltaY) && deltaTime < maxSwipeTime) {
-            if (deltaX > 0) {
-              // Swipe right - go to previous
-              handlePrevious();
-            } else {
-              // Swipe left - go to next
-              handleNext();
-            }
-          }
-        }
-
-        touchStartRef.current = null;
-        touchPanStartRef.current = null;
-      }
-    },
-    [zoom, images.length, handleNext, handlePrevious]
-  );
-
-  useEffect(() => {
-    if (isDragging) {
-      const handleGlobalMouseMove = (e: MouseEvent) => handleMouseMove(e);
-      const handleGlobalMouseUp = () => handleMouseUp();
-
-      window.addEventListener('mousemove', handleGlobalMouseMove);
-      window.addEventListener('mouseup', handleGlobalMouseUp);
-
-      return () => {
-        window.removeEventListener('mousemove', handleGlobalMouseMove);
-        window.removeEventListener('mouseup', handleGlobalMouseUp);
-      };
-    }
-  }, [isDragging, handleMouseMove, handleMouseUp]);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    container.addEventListener('wheel', handleWheel, { passive: false });
-    window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      container.removeEventListener('wheel', handleWheel);
-      window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [handleWheel, handleKeyDown, handleClickOutside]);
-
-  // Preload adjacent images
-  useEffect(() => {
-    if (!currentSelectedImage || images.length <= 1) return;
-
-    const currentIndex = images.findIndex(img => img.id === currentSelectedImage.id);
-    const nextImage = images[(currentIndex + 1) % images.length];
-    const prevImage = images[(currentIndex - 1 + images.length) % images.length];
-
-    // Preload adjacent images
-    [nextImage, prevImage].forEach(img => {
-      const link = document.createElement('link');
-      link.rel = 'prefetch';
-      link.href = img.src;
-      document.head.appendChild(link);
-    });
-  }, [currentSelectedImage, images]);
-
-  if (!selectedImage) {
-    return null;
-  }
+  const hasMultipleImages = images.length > 1;
+  const canReset = zoom !== 1 || rotationCount % 4 !== 0;
 
   return (
     <div
       ref={containerRef}
       className="photo-viewer"
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label={currentImage.title || 'Photo viewer'}
+      style={backdropStyle}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       <Navigation
-        title={currentSelectedImage?.title || 'Photo Viewer'}
+        title={currentImage.title || 'Photo Viewer'}
         onClose={onClose}
-        onNext={images.length > 1 ? handleNext : undefined}
-        onPrevious={images.length > 1 ? handlePrevious : undefined}
-        onZoomIn={allowZoom ? () => handleZoom(zoom + zoomStep) : undefined}
-        onZoomOut={allowZoom ? () => handleZoom(zoom - zoomStep) : undefined}
+        onNext={hasMultipleImages ? next : undefined}
+        onPrevious={hasMultipleImages ? previous : undefined}
+        onZoomIn={allowZoom ? handleZoomIn : undefined}
+        onZoomOut={allowZoom ? handleZoomOut : undefined}
         onRotate={allowRotate ? handleRotate : undefined}
-        onReset={zoom !== 1 || rotationCount % 4 !== 0 ? handleReset : undefined}
+        onReset={canReset ? handleReset : undefined}
         onDownload={allowDownload ? handleDownload : undefined}
         onToggleOverlay={
-          showOverlayButton && currentSelectedImage?.svgOverlay ? () => setShowOverlay(!showOverlay) : undefined
+          showOverlayButton && currentImage.svgOverlay
+            ? () => setShowOverlay(prev => !prev)
+            : undefined
         }
         showOverlay={showOverlay}
         showControls={isHovered}
@@ -521,85 +228,26 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
 
       <div
         ref={imageContainerRef}
-        style={{
-          position: 'relative',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          overflow: 'hidden',
-          cursor: zoom > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default',
-          touchAction: 'none',
-        }}
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
+        style={imageContainerStyle}
+        onMouseDown={onMouseDown}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
       >
-        <div
-          style={{
-            position: 'relative',
-            transform: `translate(${panX}px, ${panY}px) rotateZ(${rotationCount * 90}deg) scale(${zoom})`,
-            transformOrigin: 'center',
-            transition: isDragging ? 'none' : 'transform 0.2s ease',
-            display: 'inline-block',
-          }}
-        >
-          {isLoading && (
-            <div
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                height: '100%',
-                backgroundColor: '#f0f0f0',
-                animation: 'pulse 1.5s infinite',
-                zIndex: 1,
-              }}
-            />
-          )}
-          <img
-            ref={imageRef}
-            src={currentSelectedImage?.src}
-            alt={currentSelectedImage?.alt || ''}
-            onDoubleClick={handleDoubleClick}
-            onLoad={() => setIsLoading(false)}
-            draggable={false}
-            style={{
-              maxWidth: '80vw',
-              maxHeight: '80vh',
-              objectFit: 'contain',
-              display: 'block',
-              userSelect: 'none',
-              opacity: isLoading ? 0 : 1,
-              transition: 'opacity 0.3s ease',
-              position: 'relative',
-              zIndex: 2,
-            }}
-          />
-          {showOverlay && currentSelectedImage?.svgOverlay && (
-            <ImageOverlay
-              overlay={currentSelectedImage.svgOverlay}
-              position={currentSelectedImage.overlayPosition}
-              size={currentSelectedImage.overlaySize}
-            />
-          )}
-        </div>
+        <PhotoViewerImage
+          image={currentImage}
+          zoom={zoom}
+          panX={panX}
+          panY={panY}
+          rotationCount={rotationCount}
+          isDragging={isDragging}
+          showOverlay={showOverlay}
+          imageRef={imageRef}
+          onDoubleClick={handleDoubleClick}
+        />
       </div>
-      <style>
-        {`
-          @keyframes pulse {
-            0% { opacity: 0.6; }
-            50% { opacity: 0.8; }
-            100% { opacity: 0.6; }
-          }
-        `}
-      </style>
+
+      {keyframesStyle}
     </div>
   );
 };

--- a/src/components/photo-viewer/PhotoViewerImage.tsx
+++ b/src/components/photo-viewer/PhotoViewerImage.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import ImageOverlay from './ImageOverlay';
+import type { ZZImage } from '../../types/image.type';
+
+type Props = {
+  image: ZZImage;
+  zoom: number;
+  panX: number;
+  panY: number;
+  rotationCount: number;
+  isDragging: boolean;
+  showOverlay: boolean;
+  imageRef: React.Ref<HTMLImageElement>;
+  onDoubleClick: () => void;
+};
+
+const skeletonStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  backgroundColor: '#f0f0f0',
+  animation: 'pulse 1.5s infinite',
+  zIndex: 1,
+};
+
+const baseImageStyle: React.CSSProperties = {
+  maxWidth: '80vw',
+  maxHeight: '80vh',
+  objectFit: 'contain',
+  display: 'block',
+  userSelect: 'none',
+  transition: 'opacity 0.3s ease',
+  position: 'relative',
+  zIndex: 2,
+};
+
+export const PhotoViewerImage: React.FC<Props> = ({
+  image,
+  zoom,
+  panX,
+  panY,
+  rotationCount,
+  isDragging,
+  showOverlay,
+  imageRef,
+  onDoubleClick,
+}) => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setIsLoading(true);
+  }, [image.id]);
+
+  const wrapperStyle: React.CSSProperties = {
+    position: 'relative',
+    transform: `translate(${panX}px, ${panY}px) rotateZ(${rotationCount * 90}deg) scale(${zoom})`,
+    transformOrigin: 'center',
+    transition: isDragging ? 'none' : 'transform 0.2s ease',
+    display: 'inline-block',
+  };
+
+  return (
+    <div style={wrapperStyle}>
+      {isLoading && <div style={skeletonStyle} />}
+      <img
+        ref={imageRef}
+        src={image.src}
+        alt={image.alt || ''}
+        onDoubleClick={onDoubleClick}
+        onLoad={() => setIsLoading(false)}
+        draggable={false}
+        style={{ ...baseImageStyle, opacity: isLoading ? 0 : 1 }}
+      />
+      {showOverlay && image.svgOverlay && (
+        <ImageOverlay
+          overlay={image.svgOverlay}
+          position={image.overlayPosition}
+          size={image.overlaySize}
+        />
+      )}
+    </div>
+  );
+};
+
+export default PhotoViewerImage;

--- a/src/components/photo-viewer/types.ts
+++ b/src/components/photo-viewer/types.ts
@@ -1,0 +1,14 @@
+export type PhotoViewerSettings = {
+  allowZoom: boolean;
+  allowRotate: boolean;
+  allowReset: boolean;
+  allowDownload: boolean;
+  doubleClickZoom: number;
+  clickOutsideToExit: boolean;
+  keyboardInteraction: boolean;
+  maxZoom: number;
+  minZoom: number;
+  zoomStep: number;
+  showOverlayByDefault?: boolean;
+  showOverlayButton?: boolean;
+};

--- a/src/hooks/photo-viewer/useClickOutsideToClose.ts
+++ b/src/hooks/photo-viewer/useClickOutsideToClose.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+
+const IGNORE_SELECTORS = ['.photo-viewer img', '.photo-viewer-navigation', '.nav-action-button'];
+
+export function useClickOutsideToClose({
+  enabled,
+  onClose,
+}: {
+  enabled: boolean;
+  onClose: () => void;
+}): void {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      for (const selector of IGNORE_SELECTORS) {
+        if (target.closest(selector)) return;
+      }
+      onCloseRef.current();
+    };
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [enabled]);
+}

--- a/src/hooks/photo-viewer/useImageNavigation.ts
+++ b/src/hooks/photo-viewer/useImageNavigation.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ZZImage } from '../../types/image.type';
+
+type UseImageNavigationInput = {
+  initialImage: ZZImage | null;
+  images: ZZImage[];
+  onImageChange?: (image: ZZImage) => void;
+};
+
+type UseImageNavigationResult = {
+  currentImage: ZZImage | null;
+  next: () => void;
+  previous: () => void;
+};
+
+export function useImageNavigation({
+  initialImage,
+  images,
+  onImageChange,
+}: UseImageNavigationInput): UseImageNavigationResult {
+  const [currentImage, setCurrentImage] = useState<ZZImage | null>(initialImage);
+
+  useEffect(() => {
+    setCurrentImage(initialImage);
+  }, [initialImage]);
+
+  const step = useCallback(
+    (direction: 1 | -1) => {
+      if (images.length === 0) return;
+      const index = images.findIndex(img => img.id === currentImage?.id);
+      const nextIndex = (index + direction + images.length) % images.length;
+      const nextImage = images[nextIndex];
+      setCurrentImage(nextImage);
+      onImageChange?.(nextImage);
+    },
+    [images, currentImage, onImageChange]
+  );
+
+  const next = useCallback(() => step(1), [step]);
+  const previous = useCallback(() => step(-1), [step]);
+
+  return { currentImage, next, previous };
+}

--- a/src/hooks/photo-viewer/useImagePreloader.ts
+++ b/src/hooks/photo-viewer/useImagePreloader.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import type { ZZImage } from '../../types/image.type';
+
+export function useImagePreloader({
+  currentImage,
+  images,
+}: {
+  currentImage: ZZImage | null;
+  images: ZZImage[];
+}): void {
+  useEffect(() => {
+    if (!currentImage || images.length <= 1) return;
+    const index = images.findIndex(img => img.id === currentImage.id);
+    if (index < 0) return;
+
+    const adjacentSrcs = [
+      images[(index + 1) % images.length].src,
+      images[(index - 1 + images.length) % images.length].src,
+    ];
+
+    const links = adjacentSrcs.map(src => {
+      const link = document.createElement('link');
+      link.rel = 'prefetch';
+      link.href = src;
+      document.head.appendChild(link);
+      return link;
+    });
+
+    return () => {
+      for (const link of links) link.remove();
+    };
+  }, [currentImage, images]);
+}

--- a/src/hooks/photo-viewer/useKeyboardShortcuts.ts
+++ b/src/hooks/photo-viewer/useKeyboardShortcuts.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+
+export type KeyboardShortcutHandlers = {
+  onClose?: () => void;
+  onZoomIn?: () => void;
+  onZoomOut?: () => void;
+  onRotate?: () => void;
+  onReset?: () => void;
+  onNext?: () => void;
+  onPrevious?: () => void;
+};
+
+export function useKeyboardShortcuts({
+  enabled,
+  handlers,
+}: {
+  enabled: boolean;
+  handlers: KeyboardShortcutHandlers;
+}): void {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const h = handlersRef.current;
+      switch (e.key) {
+        case 'Escape':
+          h.onClose?.();
+          break;
+        case '+':
+        case '=':
+          h.onZoomIn?.();
+          break;
+        case '-':
+          h.onZoomOut?.();
+          break;
+        case 'r':
+          h.onRotate?.();
+          break;
+        case '0':
+          h.onReset?.();
+          break;
+        case 'ArrowRight':
+          h.onNext?.();
+          break;
+        case 'ArrowLeft':
+          h.onPrevious?.();
+          break;
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [enabled]);
+}

--- a/src/hooks/photo-viewer/useMouseDrag.ts
+++ b/src/hooks/photo-viewer/useMouseDrag.ts
@@ -1,0 +1,42 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+type UseMouseDragInput = {
+  enabled: boolean;
+  panX: number;
+  panY: number;
+  onPan: (panX: number, panY: number) => void;
+};
+
+export function useMouseDrag({ enabled, panX, panY, onPan }: UseMouseDragInput) {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const onPanRef = useRef(onPan);
+  onPanRef.current = onPan;
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (!enabled || e.button !== 0) return;
+      e.preventDefault();
+      dragStartRef.current = { x: e.clientX - panX, y: e.clientY - panY };
+      setIsDragging(true);
+    },
+    [enabled, panX, panY]
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const handleMove = (e: MouseEvent) => {
+      e.preventDefault();
+      onPanRef.current(e.clientX - dragStartRef.current.x, e.clientY - dragStartRef.current.y);
+    };
+    const handleUp = () => setIsDragging(false);
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+    };
+  }, [isDragging]);
+
+  return { isDragging, onMouseDown };
+}

--- a/src/hooks/photo-viewer/usePhotoViewerSettings.ts
+++ b/src/hooks/photo-viewer/usePhotoViewerSettings.ts
@@ -1,0 +1,8 @@
+import type { PhotoViewerSettings } from '../../components/photo-viewer/types';
+import { DEFAULT_PHOTO_VIEWER_SETTINGS } from '../../utils/photo-viewer/constants';
+
+export function usePhotoViewerSettings(
+  overrides: Partial<PhotoViewerSettings>
+): PhotoViewerSettings {
+  return { ...DEFAULT_PHOTO_VIEWER_SETTINGS, ...overrides };
+}

--- a/src/hooks/photo-viewer/useTouchGestures.ts
+++ b/src/hooks/photo-viewer/useTouchGestures.ts
@@ -1,0 +1,143 @@
+import React, { useCallback, useRef } from 'react';
+import {
+  clamp,
+  computeZoomToPoint,
+  getContainerCenterOffset,
+} from '../../utils/photo-viewer/transformUtils';
+import {
+  detectHorizontalSwipe,
+  getTouchCenter,
+  getTouchDistance,
+} from '../../utils/photo-viewer/gestureUtils';
+
+type UseTouchGesturesInput = {
+  allowZoom: boolean;
+  zoom: number;
+  panX: number;
+  panY: number;
+  minZoom: number;
+  maxZoom: number;
+  imagesCount: number;
+  imageContainerRef: React.RefObject<HTMLElement | null>;
+  onZoomTo: (zoom: number, panX: number, panY: number) => void;
+  onPan: (panX: number, panY: number) => void;
+  onNext: () => void;
+  onPrevious: () => void;
+};
+
+export function useTouchGestures({
+  allowZoom,
+  zoom,
+  panX,
+  panY,
+  minZoom,
+  maxZoom,
+  imagesCount,
+  imageContainerRef,
+  onZoomTo,
+  onPan,
+  onNext,
+  onPrevious,
+}: UseTouchGesturesInput) {
+  const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
+  const lastTouchDistanceRef = useRef<number | null>(null);
+  const touchPanStartRef = useRef<{ x: number; y: number } | null>(null);
+  const isPinchingRef = useRef(false);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!allowZoom && imagesCount === 0) return;
+      const touches = e.touches;
+
+      if (touches.length === 1) {
+        const t = touches[0];
+        touchStartRef.current = { x: t.clientX, y: t.clientY, time: Date.now() };
+        if (zoom > 1) {
+          touchPanStartRef.current = { x: t.clientX - panX, y: t.clientY - panY };
+        }
+      } else if (touches.length === 2 && allowZoom) {
+        e.preventDefault();
+        isPinchingRef.current = true;
+        lastTouchDistanceRef.current = getTouchDistance(touches[0], touches[1]);
+      }
+    },
+    [allowZoom, zoom, panX, panY, imagesCount]
+  );
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      const touches = e.touches;
+      const imageContainer = imageContainerRef.current;
+      if (!imageContainer) return;
+
+      if (
+        touches.length === 2 &&
+        allowZoom &&
+        isPinchingRef.current &&
+        lastTouchDistanceRef.current !== null
+      ) {
+        e.preventDefault();
+        const distance = getTouchDistance(touches[0], touches[1]);
+        const scale = distance / lastTouchDistanceRef.current;
+        const newZoom = clamp(zoom * scale, minZoom, maxZoom);
+
+        const center = getTouchCenter(touches[0], touches[1]);
+        const rect = imageContainer.getBoundingClientRect();
+        const offset = getContainerCenterOffset(rect, center.x, center.y);
+        const newPan = computeZoomToPoint({
+          pointX: offset.x,
+          pointY: offset.y,
+          currentZoom: zoom,
+          newZoom,
+          panX,
+          panY,
+        });
+
+        onZoomTo(newZoom, newPan.panX, newPan.panY);
+        lastTouchDistanceRef.current = distance;
+      } else if (touches.length === 1 && zoom > 1 && touchPanStartRef.current) {
+        e.preventDefault();
+        const t = touches[0];
+        onPan(t.clientX - touchPanStartRef.current.x, t.clientY - touchPanStartRef.current.y);
+      }
+    },
+    [allowZoom, zoom, panX, panY, minZoom, maxZoom, imageContainerRef, onZoomTo, onPan]
+  );
+
+  const onTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      const touches = e.touches;
+      if (touches.length > 1) return;
+
+      if (isPinchingRef.current) {
+        isPinchingRef.current = false;
+        lastTouchDistanceRef.current = null;
+        return;
+      }
+
+      if (touchStartRef.current && zoom === 1 && imagesCount > 1) {
+        const t = e.changedTouches[0];
+        const swipe = detectHorizontalSwipe({
+          deltaX: t.clientX - touchStartRef.current.x,
+          deltaY: t.clientY - touchStartRef.current.y,
+          deltaTime: Date.now() - touchStartRef.current.time,
+        });
+        if (swipe === 'right') onPrevious();
+        else if (swipe === 'left') onNext();
+      }
+
+      touchStartRef.current = null;
+      touchPanStartRef.current = null;
+    },
+    [zoom, imagesCount, onNext, onPrevious]
+  );
+
+  const reset = useCallback(() => {
+    touchStartRef.current = null;
+    lastTouchDistanceRef.current = null;
+    touchPanStartRef.current = null;
+    isPinchingRef.current = false;
+  }, []);
+
+  return { onTouchStart, onTouchMove, onTouchEnd, reset };
+}

--- a/src/hooks/photo-viewer/useTransform.ts
+++ b/src/hooks/photo-viewer/useTransform.ts
@@ -1,0 +1,83 @@
+import { useCallback, useReducer } from 'react';
+import { clamp } from '../../utils/photo-viewer/transformUtils';
+
+type TransformState = {
+  zoom: number;
+  panX: number;
+  panY: number;
+  rotationCount: number;
+};
+
+type TransformAction =
+  | { type: 'reset' }
+  | { type: 'setZoom'; zoom: number }
+  | { type: 'setPan'; panX: number; panY: number }
+  | { type: 'zoomTo'; zoom: number; panX: number; panY: number }
+  | { type: 'rotate'; direction: 'left' | 'right' };
+
+const INITIAL_STATE: TransformState = { zoom: 1, panX: 0, panY: 0, rotationCount: 0 };
+
+function transformReducer(state: TransformState, action: TransformAction): TransformState {
+  switch (action.type) {
+    case 'reset':
+      return INITIAL_STATE;
+    case 'setZoom':
+      if (action.zoom === 1) return { ...state, zoom: 1, panX: 0, panY: 0 };
+      return { ...state, zoom: action.zoom };
+    case 'setPan':
+      return { ...state, panX: action.panX, panY: action.panY };
+    case 'zoomTo':
+      if (action.zoom === 1) return { ...state, zoom: 1, panX: 0, panY: 0 };
+      return { ...state, zoom: action.zoom, panX: action.panX, panY: action.panY };
+    case 'rotate':
+      return {
+        ...state,
+        rotationCount: state.rotationCount + (action.direction === 'left' ? -1 : 1),
+      };
+    default:
+      return state;
+  }
+}
+
+export type Transform = TransformState & {
+  setZoom: (zoom: number) => void;
+  setPan: (panX: number, panY: number) => void;
+  zoomTo: (zoom: number, panX: number, panY: number) => void;
+  rotate: (direction: 'left' | 'right') => void;
+  reset: () => void;
+};
+
+export function useTransform({
+  minZoom,
+  maxZoom,
+}: {
+  minZoom: number;
+  maxZoom: number;
+}): Transform {
+  const [state, dispatch] = useReducer(transformReducer, INITIAL_STATE);
+
+  const setZoom = useCallback(
+    (zoom: number) => dispatch({ type: 'setZoom', zoom: clamp(zoom, minZoom, maxZoom) }),
+    [minZoom, maxZoom]
+  );
+
+  const setPan = useCallback(
+    (panX: number, panY: number) => dispatch({ type: 'setPan', panX, panY }),
+    []
+  );
+
+  const zoomTo = useCallback(
+    (zoom: number, panX: number, panY: number) =>
+      dispatch({ type: 'zoomTo', zoom: clamp(zoom, minZoom, maxZoom), panX, panY }),
+    [minZoom, maxZoom]
+  );
+
+  const rotate = useCallback(
+    (direction: 'left' | 'right') => dispatch({ type: 'rotate', direction }),
+    []
+  );
+
+  const reset = useCallback(() => dispatch({ type: 'reset' }), []);
+
+  return { ...state, setZoom, setPan, zoomTo, rotate, reset };
+}

--- a/src/hooks/photo-viewer/useWheelZoom.ts
+++ b/src/hooks/photo-viewer/useWheelZoom.ts
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  clamp,
+  computeZoomToPoint,
+  getContainerCenterOffset,
+} from '../../utils/photo-viewer/transformUtils';
+
+type UseWheelZoomInput = {
+  enabled: boolean;
+  containerRef: React.RefObject<HTMLElement | null>;
+  imageContainerRef: React.RefObject<HTMLElement | null>;
+  zoom: number;
+  panX: number;
+  panY: number;
+  zoomStep: number;
+  minZoom: number;
+  maxZoom: number;
+  onZoomTo: (zoom: number, panX: number, panY: number) => void;
+};
+
+export function useWheelZoom({
+  enabled,
+  containerRef,
+  imageContainerRef,
+  zoom,
+  panX,
+  panY,
+  zoomStep,
+  minZoom,
+  maxZoom,
+  onZoomTo,
+}: UseWheelZoomInput): void {
+  const stateRef = useRef({ zoom, panX, panY });
+  stateRef.current = { zoom, panX, panY };
+
+  const onZoomToRef = useRef(onZoomTo);
+  onZoomToRef.current = onZoomTo;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const imageContainer = imageContainerRef.current;
+      if (!imageContainer) return;
+
+      const { zoom: curZoom, panX: curPanX, panY: curPanY } = stateRef.current;
+      const delta = e.deltaY > 0 ? -zoomStep : zoomStep;
+      const newZoom = clamp(curZoom + delta, minZoom, maxZoom);
+
+      const rect = imageContainer.getBoundingClientRect();
+      const offset = getContainerCenterOffset(rect, e.clientX, e.clientY);
+      const newPan = computeZoomToPoint({
+        pointX: offset.x,
+        pointY: offset.y,
+        currentZoom: curZoom,
+        newZoom,
+        panX: curPanX,
+        panY: curPanY,
+      });
+
+      onZoomToRef.current(newZoom, newPan.panX, newPan.panY);
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => container.removeEventListener('wheel', handleWheel);
+  }, [enabled, containerRef, imageContainerRef, zoomStep, minZoom, maxZoom]);
+}

--- a/src/utils/photo-viewer/__tests__/gestureUtils.test.ts
+++ b/src/utils/photo-viewer/__tests__/gestureUtils.test.ts
@@ -1,0 +1,58 @@
+import { detectHorizontalSwipe, getTouchCenter, getTouchDistance } from '../gestureUtils';
+
+describe('getTouchDistance', () => {
+  it('computes euclidean distance', () => {
+    expect(getTouchDistance({ clientX: 0, clientY: 0 }, { clientX: 3, clientY: 4 })).toBe(5);
+  });
+
+  it('returns 0 for identical points', () => {
+    expect(getTouchDistance({ clientX: 5, clientY: 5 }, { clientX: 5, clientY: 5 })).toBe(0);
+  });
+});
+
+describe('getTouchCenter', () => {
+  it('returns midpoint of two touches', () => {
+    expect(getTouchCenter({ clientX: 0, clientY: 0 }, { clientX: 10, clientY: 20 })).toEqual({
+      x: 5,
+      y: 10,
+    });
+  });
+});
+
+describe('detectHorizontalSwipe', () => {
+  it('detects rightward swipe', () => {
+    expect(
+      detectHorizontalSwipe({ deltaX: 80, deltaY: 5, deltaTime: 100 })
+    ).toBe('right');
+  });
+
+  it('detects leftward swipe', () => {
+    expect(
+      detectHorizontalSwipe({ deltaX: -80, deltaY: 5, deltaTime: 100 })
+    ).toBe('left');
+  });
+
+  it('returns null when time exceeds threshold', () => {
+    expect(
+      detectHorizontalSwipe({ deltaX: 80, deltaY: 5, deltaTime: 400 })
+    ).toBeNull();
+  });
+
+  it('returns null when horizontal distance below threshold', () => {
+    expect(
+      detectHorizontalSwipe({ deltaX: 30, deltaY: 5, deltaTime: 100 })
+    ).toBeNull();
+  });
+
+  it('returns null when vertical distance dominates', () => {
+    expect(
+      detectHorizontalSwipe({ deltaX: 60, deltaY: 80, deltaTime: 100 })
+    ).toBeNull();
+  });
+
+  it('respects custom thresholds', () => {
+    expect(
+      detectHorizontalSwipe({ deltaX: 20, deltaY: 0, deltaTime: 50, minDistance: 10, maxTime: 100 })
+    ).toBe('right');
+  });
+});

--- a/src/utils/photo-viewer/__tests__/transformUtils.test.ts
+++ b/src/utils/photo-viewer/__tests__/transformUtils.test.ts
@@ -1,0 +1,73 @@
+import { clamp, computeZoomToPoint, getContainerCenterOffset } from '../transformUtils';
+
+describe('clamp', () => {
+  it('returns value when within bounds', () => {
+    expect(clamp(0.5, 0.1, 1)).toBe(0.5);
+  });
+
+  it('clamps to min', () => {
+    expect(clamp(-1, 0, 5)).toBe(0);
+  });
+
+  it('clamps to max', () => {
+    expect(clamp(10, 0, 5)).toBe(5);
+  });
+
+  it('handles equal min and max', () => {
+    expect(clamp(7, 3, 3)).toBe(3);
+  });
+});
+
+describe('computeZoomToPoint', () => {
+  it('keeps the point under the cursor invariant when zooming from 1', () => {
+    const result = computeZoomToPoint({
+      pointX: 100,
+      pointY: 50,
+      currentZoom: 1,
+      newZoom: 2,
+      panX: 0,
+      panY: 0,
+    });
+    // Image point under cursor before zoom: (100, 50).
+    // After zoom, new pan must place 2 * imagePoint at cursor: pan = cursor - 2 * imagePoint.
+    expect(result).toEqual({ panX: -100, panY: -50 });
+  });
+
+  it('returns (0,0) when zooming around origin from 1 to 1', () => {
+    const result = computeZoomToPoint({
+      pointX: 0,
+      pointY: 0,
+      currentZoom: 1,
+      newZoom: 1,
+      panX: 0,
+      panY: 0,
+    });
+    expect(result).toEqual({ panX: 0, panY: 0 });
+  });
+
+  it('preserves the image point under the cursor when already panned and zoomed', () => {
+    const result = computeZoomToPoint({
+      pointX: 20,
+      pointY: 30,
+      currentZoom: 2,
+      newZoom: 4,
+      panX: 10,
+      panY: 10,
+    });
+    // imageX = (20 - 10) / 2 = 5, imageY = (30 - 10) / 2 = 10
+    // panX = 20 - 5 * 4 = 0, panY = 30 - 10 * 4 = -10
+    expect(result).toEqual({ panX: 0, panY: -10 });
+  });
+});
+
+describe('getContainerCenterOffset', () => {
+  it('returns offset of client point from container center', () => {
+    const rect = { left: 100, top: 50, width: 200, height: 100 };
+    expect(getContainerCenterOffset(rect, 200, 100)).toEqual({ x: 0, y: 0 });
+  });
+
+  it('handles points to the right/below center', () => {
+    const rect = { left: 0, top: 0, width: 100, height: 100 };
+    expect(getContainerCenterOffset(rect, 80, 70)).toEqual({ x: 30, y: 20 });
+  });
+});

--- a/src/utils/photo-viewer/constants.ts
+++ b/src/utils/photo-viewer/constants.ts
@@ -1,0 +1,24 @@
+import type { PhotoViewerSettings } from '../../components/photo-viewer/types';
+
+export const DEFAULT_ZOOM_STEP = 0.3;
+export const DEFAULT_LARGE_ZOOM = 4;
+export const DEFAULT_MIN_ZOOM = 0.5;
+export const DEFAULT_MAX_ZOOM = 4;
+
+export const SWIPE_MIN_DISTANCE = 50;
+export const SWIPE_MAX_TIME_MS = 300;
+
+export const DEFAULT_PHOTO_VIEWER_SETTINGS: PhotoViewerSettings = {
+  allowZoom: true,
+  allowRotate: true,
+  allowReset: true,
+  allowDownload: false,
+  doubleClickZoom: DEFAULT_LARGE_ZOOM,
+  clickOutsideToExit: true,
+  keyboardInteraction: true,
+  maxZoom: DEFAULT_MAX_ZOOM,
+  minZoom: DEFAULT_MIN_ZOOM,
+  zoomStep: DEFAULT_ZOOM_STEP,
+};
+
+export const EMPTY_PHOTO_VIEWER_SETTINGS: Partial<PhotoViewerSettings> = {};

--- a/src/utils/photo-viewer/gestureUtils.ts
+++ b/src/utils/photo-viewer/gestureUtils.ts
@@ -1,0 +1,39 @@
+import { SWIPE_MAX_TIME_MS, SWIPE_MIN_DISTANCE } from './constants';
+
+type Point = { clientX: number; clientY: number };
+
+export function getTouchDistance(t1: Point, t2: Point): number {
+  const dx = t1.clientX - t2.clientX;
+  const dy = t1.clientY - t2.clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function getTouchCenter(t1: Point, t2: Point): { x: number; y: number } {
+  return {
+    x: (t1.clientX + t2.clientX) / 2,
+    y: (t1.clientY + t2.clientY) / 2,
+  };
+}
+
+export type HorizontalSwipe = 'left' | 'right' | null;
+
+type DetectSwipeInput = {
+  deltaX: number;
+  deltaY: number;
+  deltaTime: number;
+  minDistance?: number;
+  maxTime?: number;
+};
+
+export function detectHorizontalSwipe({
+  deltaX,
+  deltaY,
+  deltaTime,
+  minDistance = SWIPE_MIN_DISTANCE,
+  maxTime = SWIPE_MAX_TIME_MS,
+}: DetectSwipeInput): HorizontalSwipe {
+  if (deltaTime >= maxTime) return null;
+  if (Math.abs(deltaX) <= minDistance) return null;
+  if (Math.abs(deltaX) <= Math.abs(deltaY)) return null;
+  return deltaX > 0 ? 'right' : 'left';
+}

--- a/src/utils/photo-viewer/transformUtils.ts
+++ b/src/utils/photo-viewer/transformUtils.ts
@@ -1,0 +1,39 @@
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+type ZoomToPointInput = {
+  pointX: number;
+  pointY: number;
+  currentZoom: number;
+  newZoom: number;
+  panX: number;
+  panY: number;
+};
+
+export function computeZoomToPoint({
+  pointX,
+  pointY,
+  currentZoom,
+  newZoom,
+  panX,
+  panY,
+}: ZoomToPointInput): { panX: number; panY: number } {
+  const imageX = (pointX - panX) / currentZoom;
+  const imageY = (pointY - panY) / currentZoom;
+  return {
+    panX: pointX - imageX * newZoom,
+    panY: pointY - imageY * newZoom,
+  };
+}
+
+export function getContainerCenterOffset(
+  rect: { left: number; top: number; width: number; height: number },
+  clientX: number,
+  clientY: number
+): { x: number; y: number } {
+  return {
+    x: clientX - (rect.left + rect.width / 2),
+    y: clientY - (rect.top + rect.height / 2),
+  };
+}


### PR DESCRIPTION
## Summary
- Decompose the 605-line PhotoViewer into focused hooks (zoom/pan/rotation via `useReducer`, image navigation, preloading, keyboard, mouse drag, touch gestures, wheel zoom, click-outside), pure utility modules (transform math, gesture detection, constants), and a dedicated `PhotoViewerImage` sub-component.
- Public API (`PhotoViewerProps`) unchanged.
- Adds 18 unit tests for `transformUtils` and `gestureUtils`.

`PhotoViewer.tsx` now: **253 lines** (was 605). Surface reorganized into:
- `src/components/photo-viewer/`: `PhotoViewer.tsx`, `PhotoViewerImage.tsx`, `types.ts`
- `src/hooks/photo-viewer/`: `useTransform`, `useImageNavigation`, `useImagePreloader`, `useKeyboardShortcuts`, `useMouseDrag`, `useTouchGestures`, `useWheelZoom`, `useClickOutsideToClose`, `usePhotoViewerSettings`
- `src/utils/photo-viewer/`: `constants.ts`, `transformUtils.ts`, `gestureUtils.ts` + `__tests__/`

## Notable behavior-preserving choices
- `useReducer` groups zoom/pan/rotation since zoom-to-point updates both
- Default `settings` param references a module-level constant instead of `{}` literal so a memoized parent isn't invalidated each render
- Event handlers stored in refs so wheel/keyboard/click-outside effects don't rebind on every render
- Static styles & `@keyframes` element hoisted to module-level constants
- Adjacent-image prefetch `<link>` tags clean up on effect teardown
- Added `role="dialog"`, `aria-modal="true"`, `aria-label` to the backdrop
- Preserved the original quirk that keyboard `+`/`-` still zooms regardless of `allowZoom` (wheel and double-click still gate it; UI buttons hide)

Closes #7

## Test plan
- [x] `yarn build` — passes
- [x] `yarn lint` — no new warnings/errors
- [x] `yarn test` — 18/18 pass
- [ ] Storybook smoke test: open `PhotoViewer` story; zoom/pan/rotate/keyboard/touch all work