### PR TITLE
chore: adopt canonical Prettier config and reformat

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,8 @@
 {
   "semi": true,
-  "tabWidth": 2,
-  "printWidth": 120,
   "singleQuote": true,
-  "trailingComma": "es5",
-  "bracketSpacing": true,
-  "bracketSameLine": false,
-  "arrowParens": "avoid",
-  "endOfLine": "auto"
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "endOfLine": "lf"
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "jest --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
     "prepare": "yarn build",
     "prepublishOnly": "npm run build:npm && npm test",
     "storybook": "storybook dev -p 6006",

--- a/src/components/gallery/Gallery.tsx
+++ b/src/components/gallery/Gallery.tsx
@@ -47,7 +47,7 @@ export const Gallery = ({ images }: GalleryProps) => {
         </h1>
       </div>
       <GalleryGrid>
-        {images.map(image => (
+        {images.map((image) => (
           <Image
             key={image.id}
             image={image}
@@ -58,7 +58,11 @@ export const Gallery = ({ images }: GalleryProps) => {
         ))}
       </GalleryGrid>
 
-      <PhotoViewer selectedImage={selectedImage} images={images} onClose={() => setSelectedImage(null)} />
+      <PhotoViewer
+        selectedImage={selectedImage}
+        images={images}
+        onClose={() => setSelectedImage(null)}
+      />
     </>
   );
 };

--- a/src/components/image-carousel/ImageCarousel.tsx
+++ b/src/components/image-carousel/ImageCarousel.tsx
@@ -53,7 +53,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
         onImageChange?.(images[clampedIndex], clampedIndex);
       }
     },
-    [currentIndex, images, onImageChange]
+    [currentIndex, images, onImageChange],
   );
 
   const goToNext = useCallback(() => {
@@ -101,7 +101,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
       }
       setDragOffset(deltaX);
     },
-    [isDragging]
+    [isDragging],
   );
 
   const handleMouseUp = useCallback(
@@ -128,7 +128,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
       setDragOffset(0);
       dragStartRef.current = null;
     },
-    [isDragging, goToNext, goToPrevious]
+    [isDragging, goToNext, goToPrevious],
   );
 
   // Touch drag handlers
@@ -157,7 +157,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
       }
       setDragOffset(deltaX);
     },
-    [isDragging]
+    [isDragging],
   );
 
   const handleTouchEnd = useCallback(
@@ -185,7 +185,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
       setDragOffset(0);
       dragStartRef.current = null;
     },
-    [isDragging, goToNext, goToPrevious]
+    [isDragging, goToNext, goToPrevious],
   );
 
   // Add global mouse event listeners for drag
@@ -206,7 +206,7 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
         onImageClick?.(image, index);
       }
     },
-    [onImageClick]
+    [onImageClick],
   );
 
   // Handle single image case
@@ -279,7 +279,6 @@ export const ImageCarousel: React.FC<ImageCarouselProps> = ({
           transition: isDragging ? 'none' : 'transform 0.3s ease-out',
           willChange: 'transform',
         }}
-
       >
         {images.map((image, index) => (
           <div

--- a/src/components/image/Image.tsx
+++ b/src/components/image/Image.tsx
@@ -37,11 +37,7 @@ export const Image = ({ image, size, onClick }: ImageProps) => {
   };
 
   return (
-    <div
-      key={image.id}
-      style={containerStyle}
-      onClick={onClick}
-    >
+    <div key={image.id} style={containerStyle} onClick={onClick}>
       {isLoading && (
         <div
           style={{

--- a/src/components/media-grid/MediaGrid.tsx
+++ b/src/components/media-grid/MediaGrid.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useDeferredValue, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useDeferredValue,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ZZImage } from '../../types/image.type';
 import { PhotoViewer } from '../photo-viewer/PhotoViewer';
 import { buildMediaGridRows } from './buildMediaGridRows';
@@ -48,7 +55,9 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
   );
 
   const localFiltering = localFilteringProp ?? loadMore == null;
-  const filters: MediaGridFilters = isControlled ? (filtersProp as MediaGridFilters) : uncontrolledFilters;
+  const filters: MediaGridFilters = isControlled
+    ? (filtersProp as MediaGridFilters)
+    : uncontrolledFilters;
 
   const setFilters = useCallback(
     (next: MediaGridFilters) => {
@@ -182,7 +191,9 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
       />
 
       {model.rows.length === 0 ? (
-        <p style={{ margin: '24px 0', color: '#888', fontSize: 14 }}>No items match the current filters.</p>
+        <p style={{ margin: '24px 0', color: '#888', fontSize: 14 }}>
+          No items match the current filters.
+        </p>
       ) : (
         <div style={{ height: heightStyle, minHeight: 0, position: 'relative' }}>
           {isGridUpdating && (
@@ -273,26 +284,30 @@ export const MediaGrid: React.FC<MediaGridProps> = ({
                   boxShadow: '0 -2px 12px rgba(0,0,0,0.4)',
                 }}
               >
-              <div
-                style={{
-                  height: 4,
-                  width: '100%',
-                  borderRadius: 2,
-                  backgroundColor: '#1a1a1a',
-                  opacity: 0.85,
-                  animation: 'zzMediaGridImagePulse 1.5s infinite',
-                }}
-                aria-hidden
-              />
-              Loading more photos…
-            </div>
+                <div
+                  style={{
+                    height: 4,
+                    width: '100%',
+                    borderRadius: 2,
+                    backgroundColor: '#1a1a1a',
+                    opacity: 0.85,
+                    animation: 'zzMediaGridImagePulse 1.5s infinite',
+                  }}
+                  aria-hidden
+                />
+                Loading more photos…
+              </div>
             </div>
           )}
         </div>
       )}
 
       {enablePhotoViewer && (
-        <PhotoViewer selectedImage={selectedZz} images={viewerImages} onClose={() => setSelectedZz(null)} />
+        <PhotoViewer
+          selectedImage={selectedZz}
+          images={viewerImages}
+          onClose={() => setSelectedZz(null)}
+        />
       )}
     </section>
   );

--- a/src/components/media-grid/MediaGridMonthHeaderRow.tsx
+++ b/src/components/media-grid/MediaGridMonthHeaderRow.tsx
@@ -5,7 +5,9 @@ export type MediaGridMonthHeaderRowProps = {
   label: string;
 };
 
-export const MediaGridMonthHeaderRow = memo(function MediaGridMonthHeaderRow({ label }: MediaGridMonthHeaderRowProps) {
+export const MediaGridMonthHeaderRow = memo(function MediaGridMonthHeaderRow({
+  label,
+}: MediaGridMonthHeaderRowProps) {
   return (
     <div
       style={{

--- a/src/components/media-grid/MediaGridThumbnail.tsx
+++ b/src/components/media-grid/MediaGridThumbnail.tsx
@@ -9,7 +9,10 @@ export type MediaGridThumbnailProps = {
   onClick?: (item: MediaGridItem) => void;
 };
 
-export const MediaGridThumbnail = memo(function MediaGridThumbnail({ item, onClick }: MediaGridThumbnailProps) {
+export const MediaGridThumbnail = memo(function MediaGridThumbnail({
+  item,
+  onClick,
+}: MediaGridThumbnailProps) {
   const [isLoading, setIsLoading] = useState(true);
   const displaySrc = item.thumbnailSrc ?? item.src;
 

--- a/src/components/media-grid/MediaGridThumbnailRow.tsx
+++ b/src/components/media-grid/MediaGridThumbnailRow.tsx
@@ -28,13 +28,15 @@ export const MediaGridThumbnailRow = memo(function MediaGridThumbnailRow({
         boxSizing: 'border-box',
       }}
     >
-      {padded.slice(0, columns).map((cell, idx) =>
-        cell ? (
-          <MediaGridThumbnail key={cell.id} item={cell} onClick={onThumbnailClick} />
-        ) : (
-          <div key={`empty-${idx}`} style={{ minHeight: 0 }} aria-hidden />
-        ),
-      )}
+      {padded
+        .slice(0, columns)
+        .map((cell, idx) =>
+          cell ? (
+            <MediaGridThumbnail key={cell.id} item={cell} onClick={onThumbnailClick} />
+          ) : (
+            <div key={`empty-${idx}`} style={{ minHeight: 0 }} aria-hidden />
+          ),
+        )}
     </div>
   );
 });

--- a/src/components/media-grid/MediaGridToolbar.tsx
+++ b/src/components/media-grid/MediaGridToolbar.tsx
@@ -36,7 +36,7 @@ export const MediaGridToolbar = memo(function MediaGridToolbar({
           id="zz-media-grid-search"
           type="search"
           value={filters.searchQuery}
-          onChange={e =>
+          onChange={(e) =>
             onFiltersChange({
               ...filters,
               searchQuery: e.target.value,
@@ -64,7 +64,7 @@ export const MediaGridToolbar = memo(function MediaGridToolbar({
         <select
           id="zz-media-grid-jump"
           value={jumpValue}
-          onChange={e => {
+          onChange={(e) => {
             const v = e.target.value;
             setJumpValue('');
             if (!v) return;
@@ -82,7 +82,7 @@ export const MediaGridToolbar = memo(function MediaGridToolbar({
           }}
         >
           <option value="">Select…</option>
-          {jumpMonthKeysInOrder.map(key => (
+          {jumpMonthKeysInOrder.map((key) => (
             <option key={key} value={key}>
               {jumpMonthLabelsByKey.get(key) ?? key}
             </option>

--- a/src/components/media-grid/MediaGridVirtualList.tsx
+++ b/src/components/media-grid/MediaGridVirtualList.tsx
@@ -12,7 +12,11 @@ import React, {
 import { getVisibleRowRange } from './getVisibleRowRange';
 import { MediaGridMonthHeaderRow } from './MediaGridMonthHeaderRow';
 import { MediaGridThumbnailRow } from './MediaGridThumbnailRow';
-import { MEDIA_GRID_HEADER_ROW_HEIGHT, MEDIA_GRID_OVERSCAN_PX, thumbnailRowHeightPx } from './mediaGridLayout';
+import {
+  MEDIA_GRID_HEADER_ROW_HEIGHT,
+  MEDIA_GRID_OVERSCAN_PX,
+  thumbnailRowHeightPx,
+} from './mediaGridLayout';
 import { useLoadMoreSentinel } from './useLoadMoreSentinel';
 import type { MediaGridItem, MediaGridRow } from './types';
 
@@ -56,145 +60,148 @@ const VirtualRow = memo(function VirtualRow({
   );
 });
 
-export const MediaGridVirtualList = forwardRef<MediaGridVirtualListHandle, MediaGridVirtualListProps>(
-  function MediaGridVirtualList(
-    { rows, columns, gap, rowGap, onThumbnailClick, loadMore, hasMore = false, loadingMore = false },
-    ref,
-  ) {
-    const scrollRef = useRef<HTMLDivElement | null>(null);
-    const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
-    const rafRef = useRef<number | null>(null);
+export const MediaGridVirtualList = forwardRef<
+  MediaGridVirtualListHandle,
+  MediaGridVirtualListProps
+>(function MediaGridVirtualList(
+  { rows, columns, gap, rowGap, onThumbnailClick, loadMore, hasMore = false, loadingMore = false },
+  ref,
+) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollRoot, setScrollRoot] = useState<HTMLDivElement | null>(null);
+  const rafRef = useRef<number | null>(null);
 
-    const [containerWidth, setContainerWidth] = useState(0);
-    const [scrollTop, setScrollTop] = useState(0);
-    const [viewportHeight, setViewportHeight] = useState(0);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
 
-    const thumbRowHeight = useMemo(
-      () => thumbnailRowHeightPx(containerWidth, columns, gap),
-      [containerWidth, columns, gap],
-    );
+  const thumbRowHeight = useMemo(
+    () => thumbnailRowHeightPx(containerWidth, columns, gap),
+    [containerWidth, columns, gap],
+  );
 
-    const layout = useMemo(() => {
-      const thumbH = (thumbRowHeight || 96) + rowGap;
-      const heights = rows.map(r => (r.type === 'header' ? MEDIA_GRID_HEADER_ROW_HEIGHT : thumbH));
-      const offsets: number[] = new Array(heights.length);
-      let y = 0;
-      for (let i = 0; i < heights.length; i++) {
-        offsets[i] = y;
-        y += heights[i];
-      }
-      return { heights, offsets, totalHeight: y };
-    }, [rows, thumbRowHeight, rowGap]);
+  const layout = useMemo(() => {
+    const thumbH = (thumbRowHeight || 96) + rowGap;
+    const heights = rows.map((r) => (r.type === 'header' ? MEDIA_GRID_HEADER_ROW_HEIGHT : thumbH));
+    const offsets: number[] = new Array(heights.length);
+    let y = 0;
+    for (let i = 0; i < heights.length; i++) {
+      offsets[i] = y;
+      y += heights[i];
+    }
+    return { heights, offsets, totalHeight: y };
+  }, [rows, thumbRowHeight, rowGap]);
 
-    const setScrollRef = useCallback((el: HTMLDivElement | null) => {
-      scrollRef.current = el;
-      setScrollRoot(el);
-    }, []);
+  const setScrollRef = useCallback((el: HTMLDivElement | null) => {
+    scrollRef.current = el;
+    setScrollRoot(el);
+  }, []);
 
-    useLayoutEffect(() => {
-      const el = scrollRoot;
-      if (!el) return;
+  useLayoutEffect(() => {
+    const el = scrollRoot;
+    if (!el) return;
 
-      const obs = new ResizeObserver(entries => {
-        const cr = entries[0]?.contentRect;
-        if (!cr) return;
-        setContainerWidth(cr.width);
-        setViewportHeight(el.clientHeight);
-      });
-
-      obs.observe(el);
-      setContainerWidth(el.clientWidth);
+    const obs = new ResizeObserver((entries) => {
+      const cr = entries[0]?.contentRect;
+      if (!cr) return;
+      setContainerWidth(cr.width);
       setViewportHeight(el.clientHeight);
-      return () => obs.disconnect();
-    }, [scrollRoot]);
-
-    useLayoutEffect(() => {
-      const el = scrollRoot;
-      if (!el) return;
-      // Keep scroll clamped when layout height changes.
-      const max = Math.max(0, layout.totalHeight - el.clientHeight);
-      if (el.scrollTop > max) el.scrollTop = max;
-    }, [layout.totalHeight, scrollRoot]);
-
-    const onScroll = useCallback(() => {
-      const el = scrollRef.current;
-      if (!el) return;
-      if (rafRef.current != null) return;
-      rafRef.current = window.requestAnimationFrame(() => {
-        rafRef.current = null;
-        const current = scrollRef.current;
-        if (!current) return;
-        setScrollTop(current.scrollTop);
-        setViewportHeight(current.clientHeight);
-      });
-    }, []);
-
-    useEffect(
-      () => () => {
-        if (rafRef.current != null) window.cancelAnimationFrame(rafRef.current);
-      },
-      [],
-    );
-
-    const maxRenderableRows = useMemo(() => {
-      const minRowH = Math.min(MEDIA_GRID_HEADER_ROW_HEIGHT, (thumbRowHeight || 96) + rowGap);
-      const viewport = Math.max(viewportHeight, 320);
-      return Math.max(
-        64,
-        Math.ceil((viewport + 2 * MEDIA_GRID_OVERSCAN_PX) / Math.max(1, minRowH)) + 24,
-      );
-    }, [thumbRowHeight, viewportHeight, rowGap]);
-
-    const range = useMemo(() => {
-      if (rows.length === 0) return { start: 0, end: 0 };
-      return getVisibleRowRange(
-        scrollTop,
-        viewportHeight,
-        layout.offsets,
-        layout.heights,
-        MEDIA_GRID_OVERSCAN_PX,
-        maxRenderableRows,
-      );
-    }, [rows.length, scrollTop, viewportHeight, layout.offsets, layout.heights, maxRenderableRows]);
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        scrollToRowIndex: (index: number) => {
-          const el = scrollRef.current;
-          if (!el || rows.length === 0) return;
-          const clamped = Math.max(0, Math.min(index, rows.length - 1));
-          el.scrollTop = layout.offsets[clamped] ?? 0;
-          setScrollTop(el.scrollTop);
-        },
-      }),
-      [layout.offsets, rows.length],
-    );
-
-    const sentinelRef = useLoadMoreSentinel({
-      enabled: Boolean(loadMore),
-      root: scrollRoot,
-      loading: loadingMore,
-      hasMore,
-      onLoadMore: () => loadMore?.(),
     });
 
-    return (
-      <div
-        ref={setScrollRef}
-        className="zz-media-grid-scroll"
-        onScroll={onScroll}
-        style={{
-          height: '100%',
-          minHeight: 0,
-          overflow: 'auto',
-          overscrollBehavior: 'contain',
-          WebkitOverflowScrolling: 'touch',
-        }}
-      >
-        <div style={{ height: layout.totalHeight || 0, position: 'relative' }}>
-          {range.end > range.start &&
-            Array.from({ length: range.end - range.start }, (_, k) => range.start + k).map(index => {
+    obs.observe(el);
+    setContainerWidth(el.clientWidth);
+    setViewportHeight(el.clientHeight);
+    return () => obs.disconnect();
+  }, [scrollRoot]);
+
+  useLayoutEffect(() => {
+    const el = scrollRoot;
+    if (!el) return;
+    // Keep scroll clamped when layout height changes.
+    const max = Math.max(0, layout.totalHeight - el.clientHeight);
+    if (el.scrollTop > max) el.scrollTop = max;
+  }, [layout.totalHeight, scrollRoot]);
+
+  const onScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (rafRef.current != null) return;
+    rafRef.current = window.requestAnimationFrame(() => {
+      rafRef.current = null;
+      const current = scrollRef.current;
+      if (!current) return;
+      setScrollTop(current.scrollTop);
+      setViewportHeight(current.clientHeight);
+    });
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current != null) window.cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
+
+  const maxRenderableRows = useMemo(() => {
+    const minRowH = Math.min(MEDIA_GRID_HEADER_ROW_HEIGHT, (thumbRowHeight || 96) + rowGap);
+    const viewport = Math.max(viewportHeight, 320);
+    return Math.max(
+      64,
+      Math.ceil((viewport + 2 * MEDIA_GRID_OVERSCAN_PX) / Math.max(1, minRowH)) + 24,
+    );
+  }, [thumbRowHeight, viewportHeight, rowGap]);
+
+  const range = useMemo(() => {
+    if (rows.length === 0) return { start: 0, end: 0 };
+    return getVisibleRowRange(
+      scrollTop,
+      viewportHeight,
+      layout.offsets,
+      layout.heights,
+      MEDIA_GRID_OVERSCAN_PX,
+      maxRenderableRows,
+    );
+  }, [rows.length, scrollTop, viewportHeight, layout.offsets, layout.heights, maxRenderableRows]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToRowIndex: (index: number) => {
+        const el = scrollRef.current;
+        if (!el || rows.length === 0) return;
+        const clamped = Math.max(0, Math.min(index, rows.length - 1));
+        el.scrollTop = layout.offsets[clamped] ?? 0;
+        setScrollTop(el.scrollTop);
+      },
+    }),
+    [layout.offsets, rows.length],
+  );
+
+  const sentinelRef = useLoadMoreSentinel({
+    enabled: Boolean(loadMore),
+    root: scrollRoot,
+    loading: loadingMore,
+    hasMore,
+    onLoadMore: () => loadMore?.(),
+  });
+
+  return (
+    <div
+      ref={setScrollRef}
+      className="zz-media-grid-scroll"
+      onScroll={onScroll}
+      style={{
+        height: '100%',
+        minHeight: 0,
+        overflow: 'auto',
+        overscrollBehavior: 'contain',
+        WebkitOverflowScrolling: 'touch',
+      }}
+    >
+      <div style={{ height: layout.totalHeight || 0, position: 'relative' }}>
+        {range.end > range.start &&
+          Array.from({ length: range.end - range.start }, (_, k) => range.start + k).map(
+            (index) => {
               const row = rows[index];
               const height = layout.heights[index];
               const top = layout.offsets[index];
@@ -212,31 +219,34 @@ export const MediaGridVirtualList = forwardRef<MediaGridVirtualListHandle, Media
                     top,
                     height,
                     boxSizing: 'border-box',
-                    ...(row.type === 'header'
-                      ? {}
-                      : { paddingBottom: rowGap }),
+                    ...(row.type === 'header' ? {} : { paddingBottom: rowGap }),
                   }}
                 >
-                  <VirtualRow row={row} columns={columns} gap={gap} onThumbnailClick={onThumbnailClick} />
+                  <VirtualRow
+                    row={row}
+                    columns={columns}
+                    gap={gap}
+                    onThumbnailClick={onThumbnailClick}
+                  />
                 </div>
               );
-            })}
-          {loadMore && layout.totalHeight > 0 && (
-            <div
-              ref={sentinelRef as React.LegacyRef<HTMLDivElement>}
-              style={{
-                position: 'absolute',
-                top: Math.max(0, layout.totalHeight - 1),
-                left: 0,
-                width: '100%',
-                height: 1,
-                pointerEvents: 'none',
-              }}
-              aria-hidden
-            />
+            },
           )}
-        </div>
+        {loadMore && layout.totalHeight > 0 && (
+          <div
+            ref={sentinelRef as React.LegacyRef<HTMLDivElement>}
+            style={{
+              position: 'absolute',
+              top: Math.max(0, layout.totalHeight - 1),
+              left: 0,
+              width: '100%',
+              height: 1,
+              pointerEvents: 'none',
+            }}
+            aria-hidden
+          />
+        )}
       </div>
-    );
-  },
-);
+    </div>
+  );
+});

--- a/src/components/media-grid/filterMediaGridItems.ts
+++ b/src/components/media-grid/filterMediaGridItems.ts
@@ -4,11 +4,14 @@ function normalizeQuery(q: string): string {
   return q.trim().toLowerCase();
 }
 
-export function filterMediaGridItems(items: MediaGridItem[], filters: MediaGridFilters): MediaGridItem[] {
+export function filterMediaGridItems(
+  items: MediaGridItem[],
+  filters: MediaGridFilters,
+): MediaGridItem[] {
   const q = normalizeQuery(filters.searchQuery);
   const { dateFromMs, dateToMs } = filters;
 
-  return items.filter(item => {
+  return items.filter((item) => {
     if (q && !normalizeQuery(item.name).includes(q)) return false;
     if (dateFromMs != null && item.createdAt < dateFromMs) return false;
     if (dateToMs != null && item.createdAt > dateToMs) return false;

--- a/src/components/media-grid/monthKeyUtc.ts
+++ b/src/components/media-grid/monthKeyUtc.ts
@@ -40,7 +40,10 @@ export function parseMonthInputValue(value: string): { year: number; month: numb
 }
 
 /** Newest-first UTC `YYYY-MM` keys (e.g. jump menu for the last N months). */
-export function utcMonthKeysDescending(count: number, refUtc: Date | number = Date.now()): string[] {
+export function utcMonthKeysDescending(
+  count: number,
+  refUtc: Date | number = Date.now(),
+): string[] {
   const ref = typeof refUtc === 'number' ? new Date(refUtc) : refUtc;
   const keys: string[] = [];
   const y = ref.getUTCFullYear();

--- a/src/components/media-grid/useLoadMoreSentinel.ts
+++ b/src/components/media-grid/useLoadMoreSentinel.ts
@@ -27,8 +27,8 @@ export function useLoadMoreSentinel({
 
     const el = ref.current;
     const observer = new IntersectionObserver(
-      entries => {
-        const hit = entries.some(e => e.isIntersecting);
+      (entries) => {
+        const hit = entries.some((e) => e.isIntersecting);
         if (!hit || loading || !hasMore) return;
         void onLoadMore();
       },

--- a/src/components/photo-viewer/ImageOverlay.tsx
+++ b/src/components/photo-viewer/ImageOverlay.tsx
@@ -7,7 +7,11 @@ interface ImageOverlayProps {
   size?: OverlaySize;
 }
 
-export const ImageOverlay: React.FC<ImageOverlayProps> = ({ overlay, position = 'center', size = {} }) => {
+export const ImageOverlay: React.FC<ImageOverlayProps> = ({
+  overlay,
+  position = 'center',
+  size = {},
+}) => {
   // Calculate position styles
   const getPositionStyles = (pos: OverlayPosition): React.CSSProperties => {
     const styles: React.CSSProperties = {};
@@ -67,11 +71,13 @@ export const ImageOverlay: React.FC<ImageOverlayProps> = ({ overlay, position = 
     const sizeStyles: React.CSSProperties = {};
 
     if (size.maxWidth !== undefined) {
-      sizeStyles.maxWidth = typeof size.maxWidth === 'number' ? `${size.maxWidth}px` : size.maxWidth;
+      sizeStyles.maxWidth =
+        typeof size.maxWidth === 'number' ? `${size.maxWidth}px` : size.maxWidth;
     }
 
     if (size.maxHeight !== undefined) {
-      sizeStyles.maxHeight = typeof size.maxHeight === 'number' ? `${size.maxHeight}px` : size.maxHeight;
+      sizeStyles.maxHeight =
+        typeof size.maxHeight === 'number' ? `${size.maxHeight}px` : size.maxHeight;
     }
 
     if (size.width !== undefined) {

--- a/src/components/photo-viewer/Navigation.tsx
+++ b/src/components/photo-viewer/Navigation.tsx
@@ -82,18 +82,32 @@ export const Navigation: React.FC<NavigationProps> = ({
           zIndex: 9999,
         }}
       >
-        <div className="photo-viewer-navigation-title" style={{ color: 'white', fontSize: '0.9rem' }}>
+        <div
+          className="photo-viewer-navigation-title"
+          style={{ color: 'white', fontSize: '0.9rem' }}
+        >
           {title}
         </div>
-        <div className="photo-viewer-navigation-controls" style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <div
+          className="photo-viewer-navigation-controls"
+          style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
+        >
           {onReset && <NavigationActionButton icon={ResetIcon} onClick={onReset} />}
           {onPrevious && <NavigationActionButton icon={ArrowIcon} onClick={onPrevious} />}
-          {onNext && <NavigationActionButton icon={ArrowIcon} onClick={onNext} transform="rotateY(180deg)" />}
+          {onNext && (
+            <NavigationActionButton icon={ArrowIcon} onClick={onNext} transform="rotateY(180deg)" />
+          )}
           {onZoomOut && <NavigationActionButton icon={ZoomOutIcon} onClick={onZoomOut} />}
           {onZoomIn && <NavigationActionButton icon={ZoomInIcon} onClick={onZoomIn} />}
-          {onRotate && <NavigationActionButton icon={RotateIcon} onClick={() => onRotate('left')} />}
           {onRotate && (
-            <NavigationActionButton icon={RotateIcon} onClick={() => onRotate('right')} transform="rotateY(180deg)" />
+            <NavigationActionButton icon={RotateIcon} onClick={() => onRotate('left')} />
+          )}
+          {onRotate && (
+            <NavigationActionButton
+              icon={RotateIcon}
+              onClick={() => onRotate('right')}
+              transform="rotateY(180deg)"
+            />
           )}
           {onToggleOverlay && (
             <NavigationActionButton

--- a/src/components/photo-viewer/PhotoViewer.tsx
+++ b/src/components/photo-viewer/PhotoViewer.tsx
@@ -81,7 +81,17 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const imageRef = useRef<HTMLImageElement>(null);
 
   const transform = useTransform({ minZoom, maxZoom });
-  const { zoom, panX, panY, rotationCount, setZoom, setPan, zoomTo, rotate, reset: resetTransform } = transform;
+  const {
+    zoom,
+    panX,
+    panY,
+    rotationCount,
+    setZoom,
+    setPan,
+    zoomTo,
+    rotate,
+    reset: resetTransform,
+  } = transform;
 
   const { currentImage, next, previous } = useImageNavigation({
     initialImage: selectedImage,
@@ -91,7 +101,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
 
   const [isHovered, setIsHovered] = useState(false);
   const [showOverlay, setShowOverlay] = useState(
-    () => showOverlayByDefault && !!selectedImage?.svgOverlay
+    () => showOverlayByDefault && !!selectedImage?.svgOverlay,
   );
 
   useEffect(() => {
@@ -102,7 +112,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const currentHasOverlay = !!currentImage?.svgOverlay;
   useEffect(() => {
     resetTransform();
-    setShowOverlay(prev => (currentHasOverlay ? prev : false));
+    setShowOverlay((prev) => (currentHasOverlay ? prev : false));
   }, [currentImageId, currentHasOverlay, resetTransform]);
 
   useImagePreloader({ currentImage, images });
@@ -119,7 +129,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     (direction: 'left' | 'right' = 'right') => {
       if (allowRotate) rotate(direction);
     },
-    [allowRotate, rotate]
+    [allowRotate, rotate],
   );
 
   const handleReset = useCallback(() => {
@@ -139,7 +149,12 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     onPan: setPan,
   });
 
-  const { onTouchStart, onTouchMove, onTouchEnd, reset: resetTouchGestures } = useTouchGestures({
+  const {
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+    reset: resetTouchGestures,
+  } = useTouchGestures({
     allowZoom,
     zoom,
     panX,
@@ -219,7 +234,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
         onDownload={allowDownload ? handleDownload : undefined}
         onToggleOverlay={
           showOverlayButton && currentImage.svgOverlay
-            ? () => setShowOverlay(prev => !prev)
+            ? () => setShowOverlay((prev) => !prev)
             : undefined
         }
         showOverlay={showOverlay}

--- a/src/hooks/photo-viewer/useImageNavigation.ts
+++ b/src/hooks/photo-viewer/useImageNavigation.ts
@@ -27,13 +27,13 @@ export function useImageNavigation({
   const step = useCallback(
     (direction: 1 | -1) => {
       if (images.length === 0) return;
-      const index = images.findIndex(img => img.id === currentImage?.id);
+      const index = images.findIndex((img) => img.id === currentImage?.id);
       const nextIndex = (index + direction + images.length) % images.length;
       const nextImage = images[nextIndex];
       setCurrentImage(nextImage);
       onImageChange?.(nextImage);
     },
-    [images, currentImage, onImageChange]
+    [images, currentImage, onImageChange],
   );
 
   const next = useCallback(() => step(1), [step]);

--- a/src/hooks/photo-viewer/useImagePreloader.ts
+++ b/src/hooks/photo-viewer/useImagePreloader.ts
@@ -10,7 +10,7 @@ export function useImagePreloader({
 }): void {
   useEffect(() => {
     if (!currentImage || images.length <= 1) return;
-    const index = images.findIndex(img => img.id === currentImage.id);
+    const index = images.findIndex((img) => img.id === currentImage.id);
     if (index < 0) return;
 
     const adjacentSrcs = [
@@ -18,7 +18,7 @@ export function useImagePreloader({
       images[(index - 1 + images.length) % images.length].src,
     ];
 
-    const links = adjacentSrcs.map(src => {
+    const links = adjacentSrcs.map((src) => {
       const link = document.createElement('link');
       link.rel = 'prefetch';
       link.href = src;

--- a/src/hooks/photo-viewer/useMouseDrag.ts
+++ b/src/hooks/photo-viewer/useMouseDrag.ts
@@ -20,7 +20,7 @@ export function useMouseDrag({ enabled, panX, panY, onPan }: UseMouseDragInput) 
       dragStartRef.current = { x: e.clientX - panX, y: e.clientY - panY };
       setIsDragging(true);
     },
-    [enabled, panX, panY]
+    [enabled, panX, panY],
   );
 
   useEffect(() => {

--- a/src/hooks/photo-viewer/usePhotoViewerSettings.ts
+++ b/src/hooks/photo-viewer/usePhotoViewerSettings.ts
@@ -2,7 +2,7 @@ import type { PhotoViewerSettings } from '../../components/photo-viewer/types';
 import { DEFAULT_PHOTO_VIEWER_SETTINGS } from '../../utils/photo-viewer/constants';
 
 export function usePhotoViewerSettings(
-  overrides: Partial<PhotoViewerSettings>
+  overrides: Partial<PhotoViewerSettings>,
 ): PhotoViewerSettings {
   return { ...DEFAULT_PHOTO_VIEWER_SETTINGS, ...overrides };
 }

--- a/src/hooks/photo-viewer/useTouchGestures.ts
+++ b/src/hooks/photo-viewer/useTouchGestures.ts
@@ -61,7 +61,7 @@ export function useTouchGestures({
         lastTouchDistanceRef.current = getTouchDistance(touches[0], touches[1]);
       }
     },
-    [allowZoom, zoom, panX, panY, imagesCount]
+    [allowZoom, zoom, panX, panY, imagesCount],
   );
 
   const onTouchMove = useCallback(
@@ -101,7 +101,7 @@ export function useTouchGestures({
         onPan(t.clientX - touchPanStartRef.current.x, t.clientY - touchPanStartRef.current.y);
       }
     },
-    [allowZoom, zoom, panX, panY, minZoom, maxZoom, imageContainerRef, onZoomTo, onPan]
+    [allowZoom, zoom, panX, panY, minZoom, maxZoom, imageContainerRef, onZoomTo, onPan],
   );
 
   const onTouchEnd = useCallback(
@@ -129,7 +129,7 @@ export function useTouchGestures({
       touchStartRef.current = null;
       touchPanStartRef.current = null;
     },
-    [zoom, imagesCount, onNext, onPrevious]
+    [zoom, imagesCount, onNext, onPrevious],
   );
 
   const reset = useCallback(() => {

--- a/src/hooks/photo-viewer/useTransform.ts
+++ b/src/hooks/photo-viewer/useTransform.ts
@@ -58,23 +58,23 @@ export function useTransform({
 
   const setZoom = useCallback(
     (zoom: number) => dispatch({ type: 'setZoom', zoom: clamp(zoom, minZoom, maxZoom) }),
-    [minZoom, maxZoom]
+    [minZoom, maxZoom],
   );
 
   const setPan = useCallback(
     (panX: number, panY: number) => dispatch({ type: 'setPan', panX, panY }),
-    []
+    [],
   );
 
   const zoomTo = useCallback(
     (zoom: number, panX: number, panY: number) =>
       dispatch({ type: 'zoomTo', zoom: clamp(zoom, minZoom, maxZoom), panX, panY }),
-    [minZoom, maxZoom]
+    [minZoom, maxZoom],
   );
 
   const rotate = useCallback(
     (direction: 'left' | 'right') => dispatch({ type: 'rotate', direction }),
-    []
+    [],
   );
 
   const reset = useCallback(() => dispatch({ type: 'reset' }), []);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,10 @@ export {
   utcMonthKeysDescending,
   utcMonthStartMs,
 } from './components/media-grid';
-export type { BuiltMediaGridModel, MediaGridFilters, MediaGridItem, MediaGridProps, MediaGridRow } from './components/media-grid';
+export type {
+  BuiltMediaGridModel,
+  MediaGridFilters,
+  MediaGridItem,
+  MediaGridProps,
+  MediaGridRow,
+} from './components/media-grid';

--- a/src/stories/Image.stories.tsx
+++ b/src/stories/Image.stories.tsx
@@ -188,7 +188,11 @@ export const GoldenRatio: Story = {
 
 export const FixedContainerSize: Story = {
   args: {
-    image: { id: '17', src: 'https://picsum.photos/1200/800?random=17', alt: 'Fixed container size' },
+    image: {
+      id: '17',
+      src: 'https://picsum.photos/1200/800?random=17',
+      alt: 'Fixed container size',
+    },
     size: { width: 320, height: 180 },
   },
 };
@@ -210,7 +214,11 @@ export const MaxWidthAndHeight: Story = {
     </div>
   ),
   args: {
-    image: { id: '18', src: 'https://picsum.photos/1200/800?random=18', alt: 'Constrained by max size' },
+    image: {
+      id: '18',
+      src: 'https://picsum.photos/1200/800?random=18',
+      alt: 'Constrained by max size',
+    },
     size: { width: '100%', height: '100%', maxWidth: 340, maxHeight: 220 },
   },
 };
@@ -301,32 +309,47 @@ export const DifferentAspectRatios: Story = {
       {[
         {
           label: 'Landscape image in square container',
-          image: { id: '20', src: 'https://picsum.photos/1200/800?random=20', alt: 'Landscape image' },
+          image: {
+            id: '20',
+            src: 'https://picsum.photos/1200/800?random=20',
+            alt: 'Landscape image',
+          },
           size: { width: 220, height: 220 },
         },
         {
           label: 'Portrait image in landscape container',
-          image: { id: '21', src: 'https://picsum.photos/800/1200?random=21', alt: 'Portrait image' },
+          image: {
+            id: '21',
+            src: 'https://picsum.photos/800/1200?random=21',
+            alt: 'Portrait image',
+          },
           size: { width: 320, height: 180 },
         },
         {
           label: 'Square image in cinematic container',
-          image: { id: '22', src: 'https://picsum.photos/1000/1000?random=22', alt: 'Square image' },
+          image: {
+            id: '22',
+            src: 'https://picsum.photos/1000/1000?random=22',
+            alt: 'Square image',
+          },
           size: { ratio: ImageRatio.Cinematic, width: 320 },
         },
         {
           label: 'Landscape image in tall container',
-          image: { id: '23', src: 'https://picsum.photos/1200/800?random=23', alt: 'Landscape image in tall frame' },
+          image: {
+            id: '23',
+            src: 'https://picsum.photos/1200/800?random=23',
+            alt: 'Landscape image in tall frame',
+          },
           size: { ratio: ImageRatio.Tall, width: 180 },
         },
       ].map((example) => (
-        <div key={example.image.id} style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <div
+          key={example.image.id}
+          style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}
+        >
           <span style={{ fontSize: '12px', color: '#666' }}>{example.label}</span>
-          <Image
-            {...args}
-            image={example.image}
-            size={example.size}
-          />
+          <Image {...args} image={example.image} size={example.size} />
         </div>
       ))}
     </div>

--- a/src/stories/Introduction.stories.tsx
+++ b/src/stories/Introduction.stories.tsx
@@ -6,11 +6,12 @@ const IntroductionComponent = () => {
     <div style={{ padding: '2rem', maxWidth: '800px', margin: '0 auto' }}>
       <h1>zimme-zoom</h1>
       <p>
-        A collection of image-related React components packaged as an npm package. The main component is{' '}
-        <strong>PhotoViewer</strong>, a lightweight React photo viewer with zoom, navigation, blurred background, and
-        SVG overlay support. <strong>MediaGrid</strong> adds a Messenger-style month-grouped grid with search,
-        jump-to-month (full range via <code>jumpMonthKeys</code>), optional infinite loading, and built-in windowing
-        (React only—no extra list libraries).
+        A collection of image-related React components packaged as an npm package. The main
+        component is <strong>PhotoViewer</strong>, a lightweight React photo viewer with zoom,
+        navigation, blurred background, and SVG overlay support. <strong>MediaGrid</strong> adds a
+        Messenger-style month-grouped grid with search, jump-to-month (full range via{' '}
+        <code>jumpMonthKeys</code>), optional infinite loading, and built-in windowing (React
+        only—no extra list libraries).
       </p>
 
       <h2>Prerequisites</h2>
@@ -22,7 +23,9 @@ const IntroductionComponent = () => {
       </ul>
 
       <h2>Installation</h2>
-      <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}>
+      <pre
+        style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}
+      >
         {`yarn add zimme-zoom`}
       </pre>
 
@@ -30,40 +33,47 @@ const IntroductionComponent = () => {
       <p>zimme-zoom provides the following React components:</p>
       <ul>
         <li>
-          <strong>PhotoViewer</strong> - The main component: A lightweight photo viewer with zoom, navigation, blurred
-          background, and SVG overlay support
+          <strong>PhotoViewer</strong> - The main component: A lightweight photo viewer with zoom,
+          navigation, blurred background, and SVG overlay support
         </li>
         <li>
-          <strong>Gallery</strong> - A grid-based image gallery component that displays images and integrates with
-          PhotoViewer
+          <strong>Gallery</strong> - A grid-based image gallery component that displays images and
+          integrates with PhotoViewer
         </li>
         <li>
-          <strong>MediaGrid</strong> - Virtualized month-grouped image grid with search, jump-to-month, optional{' '}
-          <code>loadMore</code>, and optional PhotoViewer integration
+          <strong>MediaGrid</strong> - Virtualized month-grouped image grid with search,
+          jump-to-month, optional <code>loadMore</code>, and optional PhotoViewer integration
         </li>
         <li>
-          <strong>ImageCarousel</strong> - A swipeable image carousel with lazy loading and touch/mouse gesture support
+          <strong>ImageCarousel</strong> - A swipeable image carousel with lazy loading and
+          touch/mouse gesture support
         </li>
         <li>
-          <strong>Image</strong> - A reusable image component for displaying images with click handlers, built-in
-          loading states (pulsing placeholder), and smooth fade-in transitions
+          <strong>Image</strong> - A reusable image component for displaying images with click
+          handlers, built-in loading states (pulsing placeholder), and smooth fade-in transitions
         </li>
       </ul>
 
       <p>All components are exported from the main package:</p>
-      <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}>
+      <pre
+        style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}
+      >
         {`import { PhotoViewer, Gallery, MediaGrid, ImageCarousel, Image } from 'zimme-zoom';
 import type { ZZImage, PhotoViewerProps, MediaGridItem, MediaGridProps } from 'zimme-zoom';`}
       </pre>
 
       <p>
-        See the <strong>MediaGrid</strong> story group in the sidebar for <strong>LargeListLoadMore</strong> (multi-year catalog + pagination), defaults, and edge cases.
+        See the <strong>MediaGrid</strong> story group in the sidebar for{' '}
+        <strong>LargeListLoadMore</strong> (multi-year catalog + pagination), defaults, and edge
+        cases.
       </p>
 
       <h2>PhotoViewer Usage</h2>
 
       <h3>Basic Example</h3>
-      <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}>
+      <pre
+        style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}
+      >
         {`import { PhotoViewer } from 'zimme-zoom';
 import type { ZZImage } from 'zimme-zoom';
 
@@ -93,7 +103,9 @@ function App() {
       </pre>
 
       <h3>With SVG Overlay</h3>
-      <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}>
+      <pre
+        style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}
+      >
         {`const imageWithOverlay: ZZImage = {
   id: '2',
   src: 'https://example.com/image2.jpg',
@@ -106,8 +118,8 @@ function App() {
 
       <h2>Custom Settings</h2>
       <p>
-        The <code>settings</code> prop allows you to customize the PhotoViewer behavior. All settings are optional and
-        will use default values if not provided.
+        The <code>settings</code> prop allows you to customize the PhotoViewer behavior. All
+        settings are optional and will use default values if not provided.
       </p>
 
       <h3>Available Settings</h3>
@@ -125,7 +137,9 @@ function App() {
             <td style={{ padding: '0.5rem' }}>allowZoom</td>
             <td style={{ padding: '0.5rem' }}>boolean</td>
             <td style={{ padding: '0.5rem' }}>true</td>
-            <td style={{ padding: '0.5rem' }}>Enable/disable zoom functionality (mouse wheel, zoom buttons)</td>
+            <td style={{ padding: '0.5rem' }}>
+              Enable/disable zoom functionality (mouse wheel, zoom buttons)
+            </td>
           </tr>
           <tr style={{ borderBottom: '1px solid #eee' }}>
             <td style={{ padding: '0.5rem' }}>allowRotate</td>
@@ -137,7 +151,9 @@ function App() {
             <td style={{ padding: '0.5rem' }}>allowReset</td>
             <td style={{ padding: '0.5rem' }}>boolean</td>
             <td style={{ padding: '0.5rem' }}>true</td>
-            <td style={{ padding: '0.5rem' }}>Enable/disable reset button (resets zoom and rotation)</td>
+            <td style={{ padding: '0.5rem' }}>
+              Enable/disable reset button (resets zoom and rotation)
+            </td>
           </tr>
           <tr style={{ borderBottom: '1px solid #eee' }}>
             <td style={{ padding: '0.5rem' }}>allowDownload</td>
@@ -161,7 +177,9 @@ function App() {
             <td style={{ padding: '0.5rem' }}>keyboardInteraction</td>
             <td style={{ padding: '0.5rem' }}>boolean</td>
             <td style={{ padding: '0.5rem' }}>true</td>
-            <td style={{ padding: '0.5rem' }}>Enable/disable keyboard shortcuts (Arrow keys, +/-, r, 0, Escape)</td>
+            <td style={{ padding: '0.5rem' }}>
+              Enable/disable keyboard shortcuts (Arrow keys, +/-, r, 0, Escape)
+            </td>
           </tr>
           <tr style={{ borderBottom: '1px solid #eee' }}>
             <td style={{ padding: '0.5rem' }}>maxZoom</td>
@@ -186,7 +204,8 @@ function App() {
             <td style={{ padding: '0.5rem' }}>boolean</td>
             <td style={{ padding: '0.5rem' }}>false</td>
             <td style={{ padding: '0.5rem' }}>
-              Show SVG overlay by default when PhotoViewer opens (only applies if image has svgOverlay)
+              Show SVG overlay by default when PhotoViewer opens (only applies if image has
+              svgOverlay)
             </td>
           </tr>
           <tr style={{ borderBottom: '1px solid #eee' }}>
@@ -201,7 +220,9 @@ function App() {
       </table>
 
       <h3>Settings Example</h3>
-      <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}>
+      <pre
+        style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}
+      >
         {`<PhotoViewer
   images={images}
   selectedImage={selectedImage}
@@ -225,12 +246,14 @@ function App() {
 
       <h2>Image Component Usage</h2>
       <p>
-        The <code>Image</code> component is a reusable image component that provides built-in loading states and smooth
-        transitions.
+        The <code>Image</code> component is a reusable image component that provides built-in
+        loading states and smooth transitions.
       </p>
 
       <h3>Basic Example</h3>
-      <pre style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}>
+      <pre
+        style={{ background: '#f5f5f5', padding: '1rem', borderRadius: '4px', overflow: 'auto' }}
+      >
         {`import { Image } from 'zimme-zoom';
 import type { ZZImage } from 'zimme-zoom';
 
@@ -246,7 +269,9 @@ function App() {
       </pre>
 
       <p>
-        <strong>Explore the component stories to see all the available options and use cases!</strong>
+        <strong>
+          Explore the component stories to see all the available options and use cases!
+        </strong>
       </p>
     </div>
   );

--- a/src/stories/MediaGrid.stories.tsx
+++ b/src/stories/MediaGrid.stories.tsx
@@ -87,8 +87,7 @@ function generateCatalogLastThreeYears(seed: number): MediaGridItem[] {
     const monthStart = new Date(Date.UTC(endYear, endMonth - offset, 1));
     const y = monthStart.getUTCFullYear();
     const mo = monthStart.getUTCMonth();
-    const countThisMonth =
-      minPerMonth + Math.floor(rnd() * (maxPerMonth - minPerMonth + 1));
+    const countThisMonth = minPerMonth + Math.floor(rnd() * (maxPerMonth - minPerMonth + 1));
     const dim = daysInMonthUtc(y, mo);
 
     for (let j = 0; j < countThisMonth; j++) {
@@ -114,7 +113,10 @@ function generateCatalogLastThreeYears(seed: number): MediaGridItem[] {
   return items;
 }
 
-function generateItems(count: number, options?: { seed?: number; namePrefix?: string }): MediaGridItem[] {
+function generateItems(
+  count: number,
+  options?: { seed?: number; namePrefix?: string },
+): MediaGridItem[] {
   const seed = options?.seed ?? 1;
   const rnd = randomSeeded(seed);
   const prefix = options?.namePrefix ?? 'Photo';
@@ -167,9 +169,7 @@ function LargeListLoadMoreWrapper() {
   }
   const catalog = catalogRef.current;
 
-  const [loadedCount, setLoadedCount] = useState(() =>
-    Math.min(LARGE_LIST_PAGE, catalog.length),
-  );
+  const [loadedCount, setLoadedCount] = useState(() => Math.min(LARGE_LIST_PAGE, catalog.length));
   const [loadingMore, setLoadingMore] = useState(false);
   const [filters, setFilters] = useState<MediaGridFilters>({ searchQuery: '' });
 
@@ -178,10 +178,10 @@ function LargeListLoadMoreWrapper() {
   const loadMore = useCallback(async () => {
     if (loadingMore) return;
     setLoadingMore(true);
-    await new Promise<void>(resolve => {
+    await new Promise<void>((resolve) => {
       setTimeout(resolve, 450);
     });
-    setLoadedCount(c => {
+    setLoadedCount((c) => {
       if (c >= catalog.length) return c;
       return Math.min(c + LARGE_LIST_PAGE, catalog.length);
     });
@@ -190,13 +190,19 @@ function LargeListLoadMoreWrapper() {
 
   const accumulated = useMemo(() => catalog.slice(0, loadedCount), [catalog, loadedCount]);
 
-  const visibleItems = useMemo(() => filterMediaGridItems(accumulated, filters), [accumulated, filters]);
+  const visibleItems = useMemo(
+    () => filterMediaGridItems(accumulated, filters),
+    [accumulated, filters],
+  );
 
-  const onJumpToMonthNotLoaded = useCallback((monthKey: string) => {
-    const idx = firstIndexForMonthKey(catalog, monthKey);
-    if (idx < 0) return;
-    setLoadedCount(c => Math.max(c, idx + 1));
-  }, [catalog]);
+  const onJumpToMonthNotLoaded = useCallback(
+    (monthKey: string) => {
+      const idx = firstIndexForMonthKey(catalog, monthKey);
+      if (idx < 0) return;
+      setLoadedCount((c) => Math.max(c, idx + 1));
+    },
+    [catalog],
+  );
 
   const totalMonths = TOTAL_JUMP_MONTHS;
   const approxTotal = catalog.length;
@@ -204,11 +210,13 @@ function LargeListLoadMoreWrapper() {
   return (
     <div>
       <p style={{ maxWidth: 720, color: '#666', fontSize: 14, marginTop: 0 }}>
-        Large catalog (~{approxTotal} images) over the <strong>last {totalMonths} UTC months</strong> (~3 years),
-        with a <strong>random (seeded) count per month</strong>. Each item uses a <strong>240px grid thumb</strong> and{' '}
-        <strong>1600×1200 full</strong> for the viewer. Scroll to the bottom to load the next chunk (
-        <code>{LARGE_LIST_PAGE}</code> items). Parent filters the <em>loaded</em> slice only — in production you’d
-        refetch when <code>onFiltersChange</code> fires.
+        Large catalog (~{approxTotal} images) over the{' '}
+        <strong>last {totalMonths} UTC months</strong> (~3 years), with a{' '}
+        <strong>random (seeded) count per month</strong>. Each item uses a{' '}
+        <strong>240px grid thumb</strong> and <strong>1600×1200 full</strong> for the viewer. Scroll
+        to the bottom to load the next chunk (<code>{LARGE_LIST_PAGE}</code> items). Parent filters
+        the <em>loaded</em> slice only — in production you’d refetch when{' '}
+        <code>onFiltersChange</code> fires.
       </p>
       <MediaGrid
         items={visibleItems}

--- a/src/stories/PhotoViewer.stories.tsx
+++ b/src/stories/PhotoViewer.stories.tsx
@@ -9,7 +9,10 @@ const generateRandomSeed = (): string => {
 };
 
 // Star SVG component - maintains aspect ratio
-const StarSvg: React.FC<{ className?: string; style?: React.CSSProperties }> = ({ className, style }) => (
+const StarSvg: React.FC<{ className?: string; style?: React.CSSProperties }> = ({
+  className,
+  style,
+}) => (
   <svg
     viewBox="0 0 1024 1024"
     className={className}
@@ -224,7 +227,14 @@ const overlayImagesWithLabels: ZZImage[] = [
         <line x1="100" y1="100" x2="300" y2="100" stroke="rgba(0, 255, 0, 0.8)" strokeWidth="2" />
         <line x1="100" y1="95" x2="100" y2="105" stroke="rgba(0, 255, 0, 0.8)" strokeWidth="2" />
         <line x1="300" y1="95" x2="300" y2="105" stroke="rgba(0, 255, 0, 0.8)" strokeWidth="2" />
-        <text x="200" y="90" fill="rgba(0, 255, 0, 1)" fontSize="16" textAnchor="middle" fontWeight="bold">
+        <text
+          x="200"
+          y="90"
+          fill="rgba(0, 255, 0, 1)"
+          fontSize="16"
+          textAnchor="middle"
+          fontWeight="bold"
+        >
           200px
         </text>
 
@@ -243,7 +253,14 @@ const overlayImagesWithLabels: ZZImage[] = [
           to toggle this overlay
         </text>
         <circle cx="625" cy="530" r="5" fill="rgba(255, 0, 0, 0.8)" />
-        <line x1="625" y1="530" x2="700" y2="500" stroke="rgba(255, 255, 255, 0.8)" strokeWidth="1" />
+        <line
+          x1="625"
+          y1="530"
+          x2="700"
+          y2="500"
+          stroke="rgba(255, 255, 255, 0.8)"
+          strokeWidth="1"
+        />
       </svg>
     ),
   },
@@ -262,11 +279,23 @@ const overlayImagesWithLabels: ZZImage[] = [
       >
         <defs>
           <pattern id="grid-pattern" width="5" height="5" patternUnits="userSpaceOnUse">
-            <path d="M 5 0 L 0 0 0 5" fill="none" stroke="rgba(255, 255, 255, 0.5)" strokeWidth="0.3" />
+            <path
+              d="M 5 0 L 0 0 0 5"
+              fill="none"
+              stroke="rgba(255, 255, 255, 0.5)"
+              strokeWidth="0.3"
+            />
           </pattern>
         </defs>
         <rect width="100" height="100" fill="url(#grid-pattern)" />
-        <text x="50" y="95" fill="rgba(255, 255, 255, 0.9)" fontSize="8" textAnchor="middle" fontWeight="bold">
+        <text
+          x="50"
+          y="95"
+          fill="rgba(255, 255, 255, 0.9)"
+          fontSize="8"
+          textAnchor="middle"
+          fontWeight="bold"
+        >
           Grid Overlay (Toggle ON/OFF)
         </text>
       </svg>

--- a/src/types/image.type.ts
+++ b/src/types/image.type.ts
@@ -1,4 +1,13 @@
-export type OverlayPosition = 'center' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'top' | 'bottom' | 'left' | 'right';
+export type OverlayPosition =
+  | 'center'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right'
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right';
 
 export type OverlaySize = {
   maxWidth?: string | number;
@@ -8,13 +17,13 @@ export type OverlaySize = {
 };
 
 export enum ImageRatio {
-  Square    = '1 / 1',
-  Portrait  = '4 / 5',
-  Tall      = '9 / 16',
+  Square = '1 / 1',
+  Portrait = '4 / 5',
+  Tall = '9 / 16',
   Landscape = '16 / 9',
-  Classic   = '4 / 3',
+  Classic = '4 / 3',
   Cinematic = '21 / 9',
-  Golden    = '1.618 / 1',
+  Golden = '1.618 / 1',
 }
 
 export type ImageSize = {

--- a/src/utils/downloadImage.ts
+++ b/src/utils/downloadImage.ts
@@ -7,7 +7,7 @@
 export const downloadImage = async (
   imageSrc: string,
   filename: string,
-  imageElement?: HTMLImageElement | null
+  imageElement?: HTMLImageElement | null,
 ): Promise<void> => {
   // Method 1: Try using canvas (works for same-origin images, even without CORS headers)
   // This works because the image is already loaded in the browser
@@ -24,7 +24,7 @@ export const downloadImage = async (
       ctx.drawImage(imageElement, 0, 0);
 
       // Convert to blob using Promise
-      const blob = await new Promise<Blob | null>(resolve => {
+      const blob = await new Promise<Blob | null>((resolve) => {
         canvas.toBlob(resolve, 'image/png');
       });
 
@@ -77,4 +77,3 @@ export const downloadImage = async (
   link.click();
   document.body.removeChild(link);
 };
-

--- a/src/utils/photo-viewer/__tests__/gestureUtils.test.ts
+++ b/src/utils/photo-viewer/__tests__/gestureUtils.test.ts
@@ -21,38 +21,34 @@ describe('getTouchCenter', () => {
 
 describe('detectHorizontalSwipe', () => {
   it('detects rightward swipe', () => {
-    expect(
-      detectHorizontalSwipe({ deltaX: 80, deltaY: 5, deltaTime: 100 })
-    ).toBe('right');
+    expect(detectHorizontalSwipe({ deltaX: 80, deltaY: 5, deltaTime: 100 })).toBe('right');
   });
 
   it('detects leftward swipe', () => {
-    expect(
-      detectHorizontalSwipe({ deltaX: -80, deltaY: 5, deltaTime: 100 })
-    ).toBe('left');
+    expect(detectHorizontalSwipe({ deltaX: -80, deltaY: 5, deltaTime: 100 })).toBe('left');
   });
 
   it('returns null when time exceeds threshold', () => {
-    expect(
-      detectHorizontalSwipe({ deltaX: 80, deltaY: 5, deltaTime: 400 })
-    ).toBeNull();
+    expect(detectHorizontalSwipe({ deltaX: 80, deltaY: 5, deltaTime: 400 })).toBeNull();
   });
 
   it('returns null when horizontal distance below threshold', () => {
-    expect(
-      detectHorizontalSwipe({ deltaX: 30, deltaY: 5, deltaTime: 100 })
-    ).toBeNull();
+    expect(detectHorizontalSwipe({ deltaX: 30, deltaY: 5, deltaTime: 100 })).toBeNull();
   });
 
   it('returns null when vertical distance dominates', () => {
-    expect(
-      detectHorizontalSwipe({ deltaX: 60, deltaY: 80, deltaTime: 100 })
-    ).toBeNull();
+    expect(detectHorizontalSwipe({ deltaX: 60, deltaY: 80, deltaTime: 100 })).toBeNull();
   });
 
   it('respects custom thresholds', () => {
     expect(
-      detectHorizontalSwipe({ deltaX: 20, deltaY: 0, deltaTime: 50, minDistance: 10, maxTime: 100 })
+      detectHorizontalSwipe({
+        deltaX: 20,
+        deltaY: 0,
+        deltaTime: 50,
+        minDistance: 10,
+        maxTime: 100,
+      }),
     ).toBe('right');
   });
 });

--- a/src/utils/photo-viewer/transformUtils.ts
+++ b/src/utils/photo-viewer/transformUtils.ts
@@ -30,7 +30,7 @@ export function computeZoomToPoint({
 export function getContainerCenterOffset(
   rect: { left: number; top: number; width: number; height: number },
   clientX: number,
-  clientY: number
+  clientY: number,
 ): { x: number; y: number } {
   return {
     x: clientX - (rect.left + rect.width / 2),


### PR DESCRIPTION
## Summary
Reconciles this repo's Prettier config with the shared house style used across the four libraries.

## Changes
- Update `.prettierrc`: `printWidth` 120→100, `trailingComma` es5→all, `endOfLine` auto→lf (drop redundant defaults)
- Add a `format:check` script
- Reformat all `src/` files; 18 tests still pass, build produces both CJS and ESM bundles