### PR TITLE
build: add conditional exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
Adds a modern conditional `exports` map so tooling resolves the correct entry per condition, alongside the existing `main`/`module`/`types` fields.

## Changes
- Add `exports["."]` with `types` → `dist/index.d.ts`, `import` → `dist/index.esm.js`, `require` → `dist/index.js`
- Intentionally do **not** set `sideEffects: false` — components inject styles at import time (e.g. `NavigationActionButton.tsx`), so the package is not side-effect-free and marking it so could let bundlers drop the style injection