### PR TITLE
test: add jest coverage reporting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,6 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts', '!src/**/*.stories.{ts,tsx}'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev": "rollup -c -w",
     "clean": "rimraf dist",
     "test": "jest --passWithNoTests",
+    "coverage": "jest --coverage --passWithNoTests",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",


### PR DESCRIPTION
## Summary
Adds test coverage reporting via Jest's built-in coverage.

## Changes
- Add `coverage` script (`jest --coverage --passWithNoTests`)
- Configure `coverageDirectory` and text + lcov reporters (collectCoverageFrom was already set)

Coverage is currently low (~3%) because only utility tests exist; component tests are added in a follow-up PR.