### PR TITLE
fix(PhotoViewer): move nav button styles out of module scope

### DIFF
--- a/src/components/photo-viewer/Navigation.tsx
+++ b/src/components/photo-viewer/Navigation.tsx
@@ -44,6 +44,12 @@ export const Navigation: React.FC<NavigationProps> = ({
     <>
       <style>
         {`
+          .nav-action-button:hover {
+            background-color: rgba(0, 0, 0, 0.05);
+          }
+          .nav-action-button:hover .nav-action-icon {
+            transform: scale(1.2);
+          }
           @media (max-width: 600px) {
             .photo-viewer-navigation {
               flex-direction: column !important;

--- a/src/components/photo-viewer/NavigationActionButton.tsx
+++ b/src/components/photo-viewer/NavigationActionButton.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 const ICON_SIZE = 18;
 
+/** `.nav-action-button` hover styles live in the `<style>` block rendered by `Navigation`. */
+
 interface NavigationActionButtonProps {
   icon: React.ComponentType<{
     width?: number | string;
@@ -54,16 +56,5 @@ export const NavigationActionButton: React.FC<NavigationActionButtonProps> = ({
     </div>
   );
 };
-
-const style = document.createElement('style');
-style.textContent = `
-  .nav-action-button:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-  }
-  .nav-action-button:hover .nav-action-icon {
-    transform: scale(1.2);
-  }
-`;
-document.head.appendChild(style);
 
 export default NavigationActionButton;


### PR DESCRIPTION
## Summary

`NavigationActionButton` created a `<style>` element and appended it to `document.head` at **module top level**, so the code ran at import time. `src/index.ts` reaches that module through `PhotoViewer` -> `Navigation`, which meant *any* server-side import of `zimme-zoom` threw `ReferenceError: document is not defined`, even when the viewer was never rendered and even for a type-only import.

The fix moves the two hover rules into the `<style>` block that `Navigation` already renders for its mobile media query. `Navigation` renders once per open viewer, so the "exactly once" guarantee now holds structurally, with no environment guard, no `useEffect`, and no de-duplication id.

## Changes

- Delete the module-level `document.createElement` / `document.head.appendChild` block from `NavigationActionButton.tsx`.
- Move `.nav-action-button:hover` and `.nav-action-button:hover .nav-action-icon` into the existing `<style>` block in `Navigation.tsx`.
- Add a short comment in `NavigationActionButton.tsx` pointing at where the styles now live.

## Verification

- Reproduced the bug first: rebuilding the pre-fix source and running `node -e "require('./dist/index.js')"` fails with `ReferenceError: document is not defined` at `dist/index.js:146`. After the fix both `require()` of the CJS entry and `import()` of the ESM entry succeed under plain Node.
- `renderToString(<PhotoViewer …/>)` now completes server-side, emitting both hover rules into the markup, with 2 `<style>` tags for 7 rendered buttons (confirming the rules are not duplicated per button).
- Storybook: hovering a control still yields `background-color: rgba(0, 0, 0, 0.05)` and icon `scale(1.2)`, with non-hovered controls transparent. Visually unchanged.
- `yarn lint`, `yarn test` (18 passing), and `yarn build` all pass.

Closes #22