### PR TITLE
build: modernize packaging with sideEffects, es2018, and dual types

### DIFF
--- a/.changeset/tidy-pugs-arrive.md
+++ b/.changeset/tidy-pugs-arrive.md
@@ -1,0 +1,13 @@
+---
+'zimme-zoom': minor
+---
+
+Modernize packaging.
+
+- Add `"sideEffects": false`, so bundlers can tree-shake the package. This is now safe because the module-level `document` access was removed.
+- Raise the TypeScript target from `es5` to `es2018`. Every browser that satisfies the React >=16.8 peer requirement supports it, and it cuts the bundle by roughly 10% (about 12 kB raw, 3 kB gzipped).
+- Rename the ESM output from `dist/index.esm.js` to `dist/index.mjs`. The package has no `"type": "module"`, so Node parsed the old `.js` ESM bundle as CommonJS and failed to load it.
+- Bundle the type declarations into a single `dist/index.d.ts` plus a `dist/index.d.mts`, and advertise them per condition in the `exports` map, so ESM consumers on `moduleResolution: node16`/`nodenext` no longer get CommonJS-flavored types.
+- Expose `./package.json` through the `exports` map.
+
+The public API is unchanged: all 27 exported values and types are identical.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,28 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      # Packs the library and consumes it the way a real dependent would.
+      # Guards the `exports` map, and guards against module-level DOM access
+      # regressing (see #22): both entries are loaded by plain Node, no jsdom.
+      - name: Package smoke test
+        run: |
+          set -euo pipefail
+          TARBALL="$PWD/$(npm pack --silent | tail -1)"
+          SMOKE="$(mktemp -d)"
+          cd "$SMOKE"
+          npm init -y > /dev/null
+          npm install --no-audit --no-fund "$TARBALL" react react-dom > /dev/null
+          node -e "
+            const m = require('zimme-zoom');
+            if (typeof m.PhotoViewer !== 'function') throw new Error('CJS entry did not export PhotoViewer');
+            console.log('CJS entry OK');
+          "
+          node --input-type=module -e "
+            const m = await import('zimme-zoom');
+            if (typeof m.PhotoViewer !== 'function') throw new Error('ESM entry did not export PhotoViewer');
+            console.log('ESM entry OK');
+          "
+
+      - name: Check types resolution
+        run: npx --yes @arethetypeswrong/cli --pack .

--- a/package.json
+++ b/package.json
@@ -3,21 +3,28 @@
   "version": "0.2.3",
   "description": "A collection of image-related React components packaged as an npm package. The main component is PhotoViewer, a lightweight React photo viewer with zoom, navigation, blurred background, and SVG overlay support",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
-      "require": "./dist/index.js"
-    }
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && rollup -c",
-    "build:npm": "npm run clean && rollup -c",
+    "build": "yarn clean && rollup -c && rimraf dist/types",
+    "build:npm": "npm run clean && rollup -c && rimraf dist/types",
     "build:storybook": "storybook build",
     "build:vercel": "storybook build",
     "dev": "rollup -c -w",
@@ -76,6 +83,7 @@
     "react-dom": "^19.2.0",
     "rimraf": "^5.0.5",
     "rollup": "^4.9.6",
+    "rollup-plugin-dts": "^6.4.1",
     "rollup-plugin-typescript2": "^0.36.0",
     "storybook": "^10.1.11",
     "ts-jest": "^29.4.6",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,25 +1,45 @@
 const typescript = require('rollup-plugin-typescript2');
+const dts = require('rollup-plugin-dts').default;
 
-module.exports = {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: 'dist/index.js',
-      format: 'cjs',
-      sourcemap: true,
-    },
-    {
-      file: 'dist/index.esm.js',
-      format: 'esm',
-      sourcemap: true,
-    },
-  ],
-  external: ['react', 'react-dom'],
-  plugins: [
-    typescript({
-      tsconfig: './tsconfig.json',
-      useTsconfigDeclarationDir: true,
-      exclude: ['**/*.stories.tsx', '**/*.stories.ts', '**/*.stories.mdx', '.storybook/**/*'],
-    }),
-  ],
-};
+const external = ['react', 'react-dom'];
+
+module.exports = [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/index.js',
+        format: 'cjs',
+        sourcemap: true,
+      },
+      {
+        // `.mjs` so Node parses this as ESM. The package has no `"type": "module"`,
+        // so a `.js` extension would be treated as CJS and fail to load.
+        file: 'dist/index.mjs',
+        format: 'esm',
+        sourcemap: true,
+      },
+    ],
+    external,
+    plugins: [
+      typescript({
+        tsconfig: './tsconfig.json',
+        useTsconfigDeclarationDir: true,
+        exclude: ['**/*.stories.tsx', '**/*.stories.ts', '**/*.stories.mdx', '.storybook/**/*'],
+      }),
+    ],
+  },
+  {
+    // Flatten the per-file declarations emitted above into a single entry point.
+    // `.d.mts` is what lets the `import` condition advertise ESM types; a copy of
+    // the unbundled `.d.ts` would not work, since its relative re-exports are
+    // extensionless and do not resolve under Node's ESM rules.
+    input: 'dist/types/index.d.ts',
+    output: [
+      { file: 'dist/index.d.ts', format: 'es' },
+      { file: 'dist/index.d.mts', format: 'es' },
+    ],
+    external,
+    plugins: [dts()],
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2018",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "jsx": "react",
     "declaration": true,
-    "declarationDir": "dist",
+    "declarationDir": "dist/types",
     "strict": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,7 +27,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/code-frame@^7.10.4":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.29.0":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
   integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
@@ -5228,7 +5228,7 @@ lz-string@^1.5.0:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
-magic-string@^0.30.0, magic-string@^0.30.17:
+magic-string@^0.30.0, magic-string@^0.30.17, magic-string@^0.30.21:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -5946,6 +5946,18 @@ rimraf@^5.0.5:
   integrity sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==
   dependencies:
     glob "^10.3.7"
+
+rollup-plugin-dts@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-6.4.1.tgz#9bec10f1b796ed022f76ff799429123c33aa88b7"
+  integrity sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.5"
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+    convert-source-map "^2.0.0"
+    magic-string "^0.30.21"
+  optionalDependencies:
+    "@babel/code-frame" "^7.29.0"
 
 rollup-plugin-typescript2@^0.36.0:
   version "0.36.0"


### PR DESCRIPTION
## Summary

Completes the packaging modernization from #29. The `exports` map half landed in #17; this covers the rest, plus a genuine ESM loading bug found along the way.

`@arethetypeswrong/cli` now reports **no problems** across all four resolution modes (it reported two distinct errors before). The public API is unchanged: all 27 exported values and types are identical, verified by diffing the export surface before and after.

## Changes

- **`sideEffects: false`.** Unblocked by #22, which removed the only module-level DOM access. Verified safe: zero column-0 browser-global access in `src/`, no CSS imports, no side-effect-only imports.
- **TS target `es5` -> `es2018`.** Every browser satisfying the React >=16.8 peer requirement supports it. Cuts both bundles by 12,245 bytes (**-10.3% raw, -10.1% gzipped**) and removes all downlevel helpers.
- **ESM output renamed to `dist/index.mjs`.** This fixes a real bug: the package has no `"type": "module"`, so Node parsed the old `dist/index.esm.js` as CommonJS and failed to load it. Node emitted `MODULE_TYPELESS_PACKAGE_JSON` and only worked by re-parsing as a fallback.
- **Declarations bundled** into a flat `dist/index.d.ts` plus a `dist/index.d.mts` via `rollup-plugin-dts`, advertised per condition in `exports`. Without the `.d.mts`, ESM consumers on `moduleResolution: node16`/`nodenext` resolved CommonJS-flavored types. A plain copy of the old `.d.ts` would not work, since its relative re-exports are extensionless and do not resolve under Node ESM rules.
- **`./package.json` exposed** through the exports map.
- **CI**: added a pack-and-import smoke test and an attw check. Both guard this PR's changes, and the smoke test doubles as a permanent regression guard for the SSR fix in #22, since it loads both entries under plain Node with no jsdom. This is the smoke test that #23 originally asked for.

`dist/` also got much tidier: 6 files instead of a mirrored declaration tree.

## Verification

- `@arethetypeswrong/cli` on the packed tarball: no problems, all four modes green.
- Packed the tarball, installed it into a clean temp project, and loaded both entries under plain Node: `require('zimme-zoom')` and `import('zimme-zoom')` both resolve `PhotoViewer` with 16 runtime exports.
- Typechecked a consumer under `moduleResolution: nodenext` with ESM, importing both values and types. Passes. (It initially caught a missing required field in my own fixture, which confirmed the types were genuinely resolving.)
- Export surface diffed programmatically before and after declaration bundling: 27 symbols, none added, none missing.
- Lint (1 pre-existing warning, untouched), `prettier --check`, and all 21 tests pass.

## Note for reviewers

`yarn.lock` is Yarn 1 format and CI uses `--frozen-lockfile`, so `rollup-plugin-dts` was added with Yarn 1 to keep the format. The lockfile diff is 14 lines. See the separate issue I am filing about the Yarn 1 / Yarn 4 mismatch.

Closes #29