### PR TITLE
feat(PhotoViewer): make the viewer keyboard and screen reader accessible

### DIFF
--- a/.changeset/spotty-pans-shave.md
+++ b/.changeset/spotty-pans-shave.md
@@ -1,0 +1,16 @@
+---
+'zimme-zoom': minor
+---
+
+Make PhotoViewer usable by keyboard and screen readers.
+
+- Every control is now a real `<button type="button">` with an accessible name, instead of a `<div onClick>` with no role, no tab stop, and no name. The controls were previously unreachable by keyboard and invisible to screen readers.
+- Focus moves into the dialog on open, is confined to it while open, and returns to the element that opened the viewer on close.
+- Focus recovers when a control removes itself, such as Reset disappearing once the transform is back to its default.
+- Page scrolling behind the backdrop is locked while the viewer is open, with the scrollbar width compensated so the page does not shift.
+- The overlay toggle exposes its state through `aria-pressed`.
+- The control bar now brightens on keyboard focus, not only on hover.
+
+Adds an optional `labels` prop for translating the accessible names, along with an exported `PhotoViewerLabels` type. Unspecified keys keep their English defaults. `PhotoViewerSettings` is now exported too; it was already part of the public props but was not reachable from the package root.
+
+Visual appearance and existing props are unchanged, and there are still no runtime dependencies.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ function App() {
   return (
     <>
       <button onClick={() => setSelectedImage(images[0])}>View Photo</button>
-      <PhotoViewer images={images} selectedImage={selectedImage} onClose={() => setSelectedImage(null)} />
+      <PhotoViewer
+        images={images}
+        selectedImage={selectedImage}
+        onClose={() => setSelectedImage(null)}
+      />
     </>
   );
 }
@@ -107,13 +111,54 @@ The `settings` prop allows you to customize the PhotoViewer behavior. All settin
 
 #### PhotoViewer Props
 
-| Prop            | Type                           | Required | Description                                                                         |
-| --------------- | ------------------------------ | -------- | ----------------------------------------------------------------------------------- |
-| `images`        | `ZZImage[]`                    | Yes      | Array of images to display                                                          |
-| `selectedImage` | `ZZImage \| null`              | Yes      | Currently selected image to display                                                 |
-| `onClose`       | `() => void`                   | Yes      | Callback function called when PhotoViewer is closed                                 |
-| `onImageChange` | `(image: ZZImage) => void`     | No       | Callback function called when the displayed image changes                           |
-| `settings`      | `Partial<PhotoViewerSettings>` | No       | Configuration object for PhotoViewer behavior (see [Settings](#available-settings)) |
+| Prop            | Type                           | Required | Description                                                                            |
+| --------------- | ------------------------------ | -------- | -------------------------------------------------------------------------------------- |
+| `images`        | `ZZImage[]`                    | Yes      | Array of images to display                                                             |
+| `selectedImage` | `ZZImage \| null`              | Yes      | Currently selected image to display                                                    |
+| `onClose`       | `() => void`                   | Yes      | Callback function called when PhotoViewer is closed                                    |
+| `onImageChange` | `(image: ZZImage) => void`     | No       | Callback function called when the displayed image changes                              |
+| `settings`      | `Partial<PhotoViewerSettings>` | No       | Configuration object for PhotoViewer behavior (see [Settings](#available-settings))    |
+| `labels`        | `Partial<PhotoViewerLabels>`   | No       | Accessible names for the dialog and its controls (see [Accessibility](#accessibility)) |
+
+#### Accessibility
+
+The viewer is a modal dialog: focus moves into it on open, stays inside while it is
+open, and returns to the element that opened it on close. Page scrolling behind the
+backdrop is locked. Every control is a real `<button>` with an accessible name, so it
+is reachable by keyboard and announced by screen readers.
+
+Control names default to English. Override any of them with the `labels` prop;
+unspecified keys keep their defaults.
+
+```tsx
+<PhotoViewer
+  images={images}
+  selectedImage={selectedImage}
+  onClose={() => setSelectedImage(null)}
+  labels={{
+    dialog: 'Képnéző',
+    close: 'Bezárás',
+    previous: 'Előző kép',
+    next: 'Következő kép',
+  }}
+/>
+```
+
+| Key             | Default                   |
+| --------------- | ------------------------- |
+| `dialog`        | `Photo viewer`            |
+| `close`         | `Close`                   |
+| `previous`      | `Previous image`          |
+| `next`          | `Next image`              |
+| `zoomIn`        | `Zoom in`                 |
+| `zoomOut`       | `Zoom out`                |
+| `rotateLeft`    | `Rotate left`             |
+| `rotateRight`   | `Rotate right`            |
+| `reset`         | `Reset zoom and rotation` |
+| `download`      | `Download image`          |
+| `toggleOverlay` | `Toggle overlay`          |
+
+`dialog` is only used when the current image has no `title`; a title takes precedence.
 
 #### Available Settings
 
@@ -188,21 +233,21 @@ function App() {
 
 ### MediaGridItem fields
 
-| Field           | Type     | Required | Description                                      |
-| -------------- | -------- | -------- | ------------------------------------------------ |
-| `id`           | `string` | Yes      | Stable unique id                                 |
-| `src`          | `string` | Yes      | Full-resolution URL (PhotoViewer and download)   |
-| `thumbnailSrc` | `string` | No       | Optional smaller URL for grid cells only         |
-| `name`         | `string` | Yes      | Display name; used for search                    |
+| Field          | Type     | Required | Description                                           |
+| -------------- | -------- | -------- | ----------------------------------------------------- |
+| `id`           | `string` | Yes      | Stable unique id                                      |
+| `src`          | `string` | Yes      | Full-resolution URL (PhotoViewer and download)        |
+| `thumbnailSrc` | `string` | No       | Optional smaller URL for grid cells only              |
+| `name`         | `string` | Yes      | Display name; used for search                         |
 | `createdAt`    | `number` | Yes      | Unix time in ms; UTC month grouping uses this instant |
-| `alt`          | `string` | No       | Shown as `img` alt text                          |
+| `alt`          | `string` | No       | Shown as `img` alt text                               |
 
 In Storybook, **MediaGrid** demos generate **`thumbnailSrc`** (240×240) and **`src`** (1600×1200) for each picsum item so the grid stays light and the viewer loads a larger asset.
 
-| Mode | Default `localFiltering` | Behavior |
-| ---- | ------------------------ | -------- |
-| Full in-memory list | `true` (when `loadMore` is not passed) | Search (and optional programmatic `dateFromMs` / `dateToMs`) run on `items` in the browser. |
-| Paged / infinite (`loadMore` passed) | `false` | Toolbar still updates filters; pass **`filters`** and **`onFiltersChange`**, and replace **`items`** from your API so results are not limited to “whatever pages are loaded.” |
+| Mode                                 | Default `localFiltering`               | Behavior                                                                                                                                                                      |
+| ------------------------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Full in-memory list                  | `true` (when `loadMore` is not passed) | Search (and optional programmatic `dateFromMs` / `dateToMs`) run on `items` in the browser.                                                                                   |
+| Paged / infinite (`loadMore` passed) | `false`                                | Toolbar still updates filters; pass **`filters`** and **`onFiltersChange`**, and replace **`items`** from your API so results are not limited to “whatever pages are loaded.” |
 
 Example with controlled filters while appending pages (parent filters the combined list):
 
@@ -248,29 +293,29 @@ You can reuse the same grouping and filter logic outside the component:
 
 ### MediaGrid props
 
-| Prop               | Type                         | Required | Description |
-| ------------------ | ---------------------------- | -------- | ----------- |
-| `items`            | `MediaGridItem[]`            | Yes      | Images to show (grouped by UTC month, newest first) |
-| `height`           | `number \| string`           | No       | Scroll area height (default `520`; numbers are pixels) |
-| `columns`          | `number`                     | No       | Columns per row (default `3`) |
-| `gap`              | `number`                     | No       | Gap between cells in px (default `4`) |
-| `rowGap`           | `number`                     | No       | Extra vertical space after each thumbnail row in px (default `6`) |
-| `maxWidth`         | `number \| string`           | No       | Max width of the panel (default `20rem`; Messenger-style). Numbers are pixels. |
-| `ariaLabel`        | `string`                     | No       | Accessible name for the grid region (default `Media grid`) |
-| `className`        | `string`                     | No       | Root `section` class |
-| `style`            | `CSSProperties`              | No       | Root inline styles |
-| `localFiltering`   | `boolean`                    | No       | When `true`, filter `items` in the browser; when `false`, parent owns filtered data. Default: `false` if `loadMore` is set, else `true`. |
-| `loadMore`         | `() => void \| Promise<void>` | No    | Called when the user scrolls near the bottom |
-| `hasMore`          | `boolean`                    | No       | When `false`, `loadMore` stops being requested |
-| `loadingMore`      | `boolean`                    | No       | While `true`, sentinel will not trigger another `loadMore` |
-| `filters`          | `MediaGridFilters`           | No       | Controlled filter state (`searchQuery`, optional `dateFromMs` / `dateToMs`) |
-| `defaultFilters`   | `MediaGridFilters`           | No       | Initial filters when uncontrolled |
-| `onFiltersChange`  | `(filters: MediaGridFilters) => void` | No | Fires when search changes (filters still support `dateFromMs` / `dateToMs` if you set them in code). |
-| `onItemClick`      | `(item: MediaGridItem) => void` | No  | Thumbnail click |
-| `enablePhotoViewer`| `boolean`                    | No       | Opens **PhotoViewer** on thumbnail click (default `false`) |
-| `labelLocale`      | `string`                     | No       | Locale for month labels (UTC); forwarded to `toLocaleDateString` |
-| `jumpMonthKeys`    | `string[]`                   | No       | Full list of `YYYY-MM` keys for Jump (newest first). Defaults to months present in `items`. |
-| `onJumpToMonthNotLoaded` | `(monthKey: string) => void` | No | User jumped to a month not in the current row model; load data until it appears (then grid scrolls). |
+| Prop                     | Type                                  | Required | Description                                                                                                                              |
+| ------------------------ | ------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `items`                  | `MediaGridItem[]`                     | Yes      | Images to show (grouped by UTC month, newest first)                                                                                      |
+| `height`                 | `number \| string`                    | No       | Scroll area height (default `520`; numbers are pixels)                                                                                   |
+| `columns`                | `number`                              | No       | Columns per row (default `3`)                                                                                                            |
+| `gap`                    | `number`                              | No       | Gap between cells in px (default `4`)                                                                                                    |
+| `rowGap`                 | `number`                              | No       | Extra vertical space after each thumbnail row in px (default `6`)                                                                        |
+| `maxWidth`               | `number \| string`                    | No       | Max width of the panel (default `20rem`; Messenger-style). Numbers are pixels.                                                           |
+| `ariaLabel`              | `string`                              | No       | Accessible name for the grid region (default `Media grid`)                                                                               |
+| `className`              | `string`                              | No       | Root `section` class                                                                                                                     |
+| `style`                  | `CSSProperties`                       | No       | Root inline styles                                                                                                                       |
+| `localFiltering`         | `boolean`                             | No       | When `true`, filter `items` in the browser; when `false`, parent owns filtered data. Default: `false` if `loadMore` is set, else `true`. |
+| `loadMore`               | `() => void \| Promise<void>`         | No       | Called when the user scrolls near the bottom                                                                                             |
+| `hasMore`                | `boolean`                             | No       | When `false`, `loadMore` stops being requested                                                                                           |
+| `loadingMore`            | `boolean`                             | No       | While `true`, sentinel will not trigger another `loadMore`                                                                               |
+| `filters`                | `MediaGridFilters`                    | No       | Controlled filter state (`searchQuery`, optional `dateFromMs` / `dateToMs`)                                                              |
+| `defaultFilters`         | `MediaGridFilters`                    | No       | Initial filters when uncontrolled                                                                                                        |
+| `onFiltersChange`        | `(filters: MediaGridFilters) => void` | No       | Fires when search changes (filters still support `dateFromMs` / `dateToMs` if you set them in code).                                     |
+| `onItemClick`            | `(item: MediaGridItem) => void`       | No       | Thumbnail click                                                                                                                          |
+| `enablePhotoViewer`      | `boolean`                             | No       | Opens **PhotoViewer** on thumbnail click (default `false`)                                                                               |
+| `labelLocale`            | `string`                              | No       | Locale for month labels (UTC); forwarded to `toLocaleDateString`                                                                         |
+| `jumpMonthKeys`          | `string[]`                            | No       | Full list of `YYYY-MM` keys for Jump (newest first). Defaults to months present in `items`.                                              |
+| `onJumpToMonthNotLoaded` | `(monthKey: string) => void`          | No       | User jumped to a month not in the current row model; load data until it appears (then grid scrolls).                                     |
 
 See the **MediaGrid** stories on [Storybook](https://zimme-zoom.vercel.app) for **LargeListLoadMore** (last ~3 years of random monthly volume + `loadMore`) and other examples.
 
@@ -300,10 +345,10 @@ function App() {
 
 #### Image Props
 
-| Prop      | Type         | Required | Description                                    |
-| --------- | ------------ | -------- | ---------------------------------------------- |
+| Prop      | Type         | Required | Description                                                                           |
+| --------- | ------------ | -------- | ------------------------------------------------------------------------------------- |
 | `image`   | `ZZImage`    | Yes      | Image object: `id`, **`src`** (full), optional **`thumbnailSrc`** (preview), `alt`, … |
-| `onClick` | `() => void` | No       | Callback function called when image is clicked |
+| `onClick` | `() => void` | No       | Callback function called when image is clicked                                        |
 
 The component is designed to work seamlessly within the `Gallery` component, but can also be used standalone in your own layouts.
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",

--- a/src/components/photo-viewer/Navigation.tsx
+++ b/src/components/photo-viewer/Navigation.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import type { PhotoViewerLabels } from './types';
 import {
   ResetIcon,
   ArrowIcon,
@@ -13,6 +14,8 @@ import NavigationActionButton from './NavigationActionButton';
 
 interface NavigationProps {
   title: string;
+  /** Already merged with the defaults by `PhotoViewer`. */
+  labels: PhotoViewerLabels;
   onClose?: (e?: React.MouseEvent) => void;
   onZoomIn?: () => void;
   onZoomOut?: () => void;
@@ -28,6 +31,7 @@ interface NavigationProps {
 
 export const Navigation: React.FC<NavigationProps> = ({
   title,
+  labels,
   onClose,
   onZoomIn,
   onZoomOut,
@@ -40,15 +44,41 @@ export const Navigation: React.FC<NavigationProps> = ({
   showOverlay = false,
   showControls = true,
 }) => {
+  // Tracked in state rather than with `:focus-within`, because the bar's
+  // background is an inline style that a stylesheet rule could only beat with
+  // `!important`. Without this a keyboard user sees a permanently dimmed bar.
+  const [isFocusWithin, setIsFocusWithin] = useState(false);
+
   return (
     <>
       <style>
         {`
+          .nav-action-button {
+            appearance: none;
+            -webkit-appearance: none;
+            border: none;
+            background-color: transparent;
+            background-image: none;
+            margin: 0;
+            color: inherit;
+            font: inherit;
+            line-height: 1;
+            text-align: center;
+            -webkit-tap-highlight-color: transparent;
+          }
           .nav-action-button:hover {
             background-color: rgba(0, 0, 0, 0.05);
           }
           .nav-action-button:hover .nav-action-icon {
             transform: scale(1.2);
+          }
+          .nav-action-button:focus-visible {
+            outline: 2px solid #ffffff;
+            outline-offset: 2px;
+            background-color: rgba(255, 255, 255, 0.15);
+          }
+          .nav-action-button:focus:not(:focus-visible) {
+            outline: none;
           }
           @media (max-width: 600px) {
             .photo-viewer-navigation {
@@ -78,7 +108,8 @@ export const Navigation: React.FC<NavigationProps> = ({
           transform: 'translateX(-50%)',
           width: '60%',
           height: '3rem',
-          backgroundColor: showControls ? 'rgba(0, 0, 0, 0.8)' : 'rgba(0, 0, 0, 0.5)',
+          backgroundColor:
+            showControls || isFocusWithin ? 'rgba(0, 0, 0, 0.8)' : 'rgba(0, 0, 0, 0.5)',
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
@@ -86,6 +117,12 @@ export const Navigation: React.FC<NavigationProps> = ({
           transition: 'background-color 0.2s ease',
           padding: '0 1.5rem',
           zIndex: 9999,
+        }}
+        onFocus={() => setIsFocusWithin(true)}
+        onBlur={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+            setIsFocusWithin(false);
+          }
         }}
       >
         <div
@@ -98,19 +135,37 @@ export const Navigation: React.FC<NavigationProps> = ({
           className="photo-viewer-navigation-controls"
           style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
         >
-          {onReset && <NavigationActionButton icon={ResetIcon} onClick={onReset} />}
-          {onPrevious && <NavigationActionButton icon={ArrowIcon} onClick={onPrevious} />}
-          {onNext && (
-            <NavigationActionButton icon={ArrowIcon} onClick={onNext} transform="rotateY(180deg)" />
+          {onReset && (
+            <NavigationActionButton icon={ResetIcon} label={labels.reset} onClick={onReset} />
           )}
-          {onZoomOut && <NavigationActionButton icon={ZoomOutIcon} onClick={onZoomOut} />}
-          {onZoomIn && <NavigationActionButton icon={ZoomInIcon} onClick={onZoomIn} />}
-          {onRotate && (
-            <NavigationActionButton icon={RotateIcon} onClick={() => onRotate('left')} />
+          {onPrevious && (
+            <NavigationActionButton icon={ArrowIcon} label={labels.previous} onClick={onPrevious} />
+          )}
+          {onNext && (
+            <NavigationActionButton
+              icon={ArrowIcon}
+              label={labels.next}
+              onClick={onNext}
+              transform="rotateY(180deg)"
+            />
+          )}
+          {onZoomOut && (
+            <NavigationActionButton icon={ZoomOutIcon} label={labels.zoomOut} onClick={onZoomOut} />
+          )}
+          {onZoomIn && (
+            <NavigationActionButton icon={ZoomInIcon} label={labels.zoomIn} onClick={onZoomIn} />
           )}
           {onRotate && (
             <NavigationActionButton
               icon={RotateIcon}
+              label={labels.rotateLeft}
+              onClick={() => onRotate('left')}
+            />
+          )}
+          {onRotate && (
+            <NavigationActionButton
+              icon={RotateIcon}
+              label={labels.rotateRight}
               onClick={() => onRotate('right')}
               transform="rotateY(180deg)"
             />
@@ -118,18 +173,22 @@ export const Navigation: React.FC<NavigationProps> = ({
           {onToggleOverlay && (
             <NavigationActionButton
               icon={OverlayIcon}
+              label={labels.toggleOverlay}
               onClick={onToggleOverlay}
+              pressed={showOverlay}
               style={showOverlay ? { backgroundColor: 'rgba(255, 255, 255, 0.2)' } : undefined}
             />
           )}
           {onDownload && (
             <NavigationActionButton
               icon={DownloadIcon}
+              label={labels.download}
               onClick={onDownload}
-              style={{ width: '12px', height: '12px' }}
             />
           )}
-          {onClose && <NavigationActionButton icon={CloseIcon} onClick={onClose} />}
+          {onClose && (
+            <NavigationActionButton icon={CloseIcon} label={labels.close} onClick={onClose} />
+          )}
         </div>
       </div>
     </>

--- a/src/components/photo-viewer/NavigationActionButton.tsx
+++ b/src/components/photo-viewer/NavigationActionButton.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 
 const ICON_SIZE = 18;
 
-/** `.nav-action-button` hover styles live in the `<style>` block rendered by `Navigation`. */
-
+/**
+ * The `nav-action-button` class is load-bearing beyond styling: it is listed in
+ * `IGNORE_SELECTORS` in `useClickOutsideToClose`, so dropping or renaming it
+ * makes every control click close the viewer. Its rules, including the browser
+ * button reset and the focus ring, live in the `<style>` block rendered by
+ * `Navigation`.
+ */
 interface NavigationActionButtonProps {
   icon: React.ComponentType<{
     width?: number | string;
@@ -12,21 +17,32 @@ interface NavigationActionButtonProps {
     className?: string;
     style?: React.CSSProperties;
   }>;
+  /** Accessible name. Required, so every control is named at compile time. */
+  label: string;
   onClick?: (e?: React.MouseEvent) => void;
+  /** Toggle state. Omitted entirely for plain buttons. */
+  pressed?: boolean;
   transform?: string;
   style?: React.CSSProperties;
 }
 
 export const NavigationActionButton: React.FC<NavigationActionButtonProps> = ({
   icon: Icon,
+  label,
   onClick,
+  pressed,
   transform,
   style: customStyle,
 }) => {
   return (
-    <div
+    <button
+      type="button"
       className="nav-action-button"
+      aria-label={label}
+      aria-pressed={pressed}
       style={{
+        // Intentionally no `backgroundColor` here: an inline background would
+        // outrank the `:hover` and `:focus-visible` rules in the stylesheet.
         minWidth: `${ICON_SIZE}px`,
         minHeight: `${ICON_SIZE}px`,
         display: 'flex',
@@ -41,19 +57,21 @@ export const NavigationActionButton: React.FC<NavigationActionButtonProps> = ({
       }}
       onClick={onClick}
     >
-      <Icon
-        width={ICON_SIZE}
-        height={ICON_SIZE}
-        fill="#ffffff"
-        className="nav-action-icon"
-        style={{
-          display: 'block',
-          width: `${ICON_SIZE}px`,
-          height: `${ICON_SIZE}px`,
-          transition: 'transform 0.2s ease-in-out',
-        }}
-      />
-    </div>
+      <span aria-hidden="true" style={{ display: 'flex' }}>
+        <Icon
+          width={ICON_SIZE}
+          height={ICON_SIZE}
+          fill="#ffffff"
+          className="nav-action-icon"
+          style={{
+            display: 'block',
+            width: `${ICON_SIZE}px`,
+            height: `${ICON_SIZE}px`,
+            transition: 'transform 0.2s ease-in-out',
+          }}
+        />
+      </span>
+    </button>
   );
 };
 

--- a/src/components/photo-viewer/PhotoViewer.tsx
+++ b/src/components/photo-viewer/PhotoViewer.tsx
@@ -1,21 +1,27 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Navigation from './Navigation';
 import PhotoViewerImage from './PhotoViewerImage';
-import type { PhotoViewerSettings } from './types';
+import type { PhotoViewerLabels, PhotoViewerSettings } from './types';
 import { ZZImage } from '../../types/image.type';
 import { downloadImage } from '../../utils/downloadImage';
-import { EMPTY_PHOTO_VIEWER_SETTINGS } from '../../utils/photo-viewer/constants';
+import {
+  EMPTY_PHOTO_VIEWER_LABELS,
+  EMPTY_PHOTO_VIEWER_SETTINGS,
+} from '../../utils/photo-viewer/constants';
+import { useBodyScrollLock } from '../../hooks/photo-viewer/useBodyScrollLock';
 import { useClickOutsideToClose } from '../../hooks/photo-viewer/useClickOutsideToClose';
+import { useFocusTrap } from '../../hooks/photo-viewer/useFocusTrap';
 import { useImageNavigation } from '../../hooks/photo-viewer/useImageNavigation';
 import { useImagePreloader } from '../../hooks/photo-viewer/useImagePreloader';
 import { useKeyboardShortcuts } from '../../hooks/photo-viewer/useKeyboardShortcuts';
 import { useMouseDrag } from '../../hooks/photo-viewer/useMouseDrag';
+import { usePhotoViewerLabels } from '../../hooks/photo-viewer/usePhotoViewerLabels';
 import { usePhotoViewerSettings } from '../../hooks/photo-viewer/usePhotoViewerSettings';
 import { useTouchGestures } from '../../hooks/photo-viewer/useTouchGestures';
 import { useTransform } from '../../hooks/photo-viewer/useTransform';
 import { useWheelZoom } from '../../hooks/photo-viewer/useWheelZoom';
 
-export type { PhotoViewerSettings } from './types';
+export type { PhotoViewerLabels, PhotoViewerSettings } from './types';
 
 export type PhotoViewerProps = {
   selectedImage: ZZImage | null;
@@ -23,6 +29,8 @@ export type PhotoViewerProps = {
   onClose: () => void;
   onImageChange?: (image: ZZImage) => void;
   settings?: Partial<PhotoViewerSettings>;
+  /** Accessible names, for translation. Unspecified keys keep their defaults. */
+  labels?: Partial<PhotoViewerLabels>;
 };
 
 const backdropStyle: React.CSSProperties = {
@@ -37,6 +45,8 @@ const backdropStyle: React.CSSProperties = {
   alignItems: 'center',
   justifyContent: 'center',
   zIndex: 1000,
+  // The dialog takes focus itself; it should not paint a ring for that.
+  outline: 'none',
 };
 
 const imageContainerBaseStyle: React.CSSProperties = {
@@ -60,7 +70,9 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   onClose,
   onImageChange,
   settings = EMPTY_PHOTO_VIEWER_SETTINGS,
+  labels: labelOverrides = EMPTY_PHOTO_VIEWER_LABELS,
 }) => {
+  const labels = usePhotoViewerLabels(labelOverrides);
   const {
     allowZoom,
     allowRotate,
@@ -201,6 +213,13 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
 
   useClickOutsideToClose({ enabled: clickOutsideToExit, onClose });
 
+  // Hooks run above the early return below, so a mounted-but-closed viewer
+  // would otherwise trap focus and lock body scroll while rendering nothing.
+  const isOpen = !!selectedImage && !!currentImage;
+
+  useFocusTrap({ enabled: isOpen, containerRef });
+  useBodyScrollLock({ enabled: isOpen });
+
   if (!selectedImage || !currentImage) return null;
 
   const imageContainerStyle: React.CSSProperties = {
@@ -217,13 +236,15 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       className="photo-viewer"
       role="dialog"
       aria-modal="true"
-      aria-label={currentImage.title || 'Photo viewer'}
+      aria-label={currentImage.title || labels.dialog}
+      tabIndex={-1}
       style={backdropStyle}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
       <Navigation
         title={currentImage.title || 'Photo Viewer'}
+        labels={labels}
         onClose={onClose}
         onNext={hasMultipleImages ? next : undefined}
         onPrevious={hasMultipleImages ? previous : undefined}

--- a/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
+++ b/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
@@ -1,0 +1,371 @@
+import '@testing-library/jest-dom';
+import React, { useState } from 'react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PhotoViewer } from '../PhotoViewer';
+import type { ZZImage } from '../../../types/image.type';
+
+const images: ZZImage[] = [
+  { id: '1', src: 'https://example.com/1.jpg', alt: 'First image' },
+  { id: '2', src: 'https://example.com/2.jpg', alt: 'Second image' },
+];
+
+const overlayImage: ZZImage = {
+  id: '3',
+  src: 'https://example.com/3.jpg',
+  alt: 'Third image',
+  svgOverlay: '<circle cx="5" cy="5" r="4" />',
+};
+
+/** Every control rendered with the default settings and more than one image. */
+const DEFAULT_CONTROL_NAMES = [
+  'Previous image',
+  'Next image',
+  'Zoom out',
+  'Zoom in',
+  'Rotate left',
+  'Rotate right',
+  'Close',
+];
+
+afterEach(() => {
+  // The scroll lock keeps module-level state; reset so failures do not cascade.
+  document.body.style.overflow = '';
+  document.body.style.paddingRight = '';
+});
+
+describe('PhotoViewer accessibility', () => {
+  describe('control semantics', () => {
+    it('renders every control as a native button with an accessible name', () => {
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      for (const name of DEFAULT_CONTROL_NAMES) {
+        const button = screen.getByRole('button', { name });
+        expect(button.tagName).toBe('BUTTON');
+        expect(button).toHaveAttribute('type', 'button');
+      }
+    });
+
+    it('keeps the nav-action-button class, which useClickOutsideToClose depends on', () => {
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      for (const name of DEFAULT_CONTROL_NAMES) {
+        expect(screen.getByRole('button', { name })).toHaveClass('nav-action-button');
+      }
+    });
+
+    it('hides the icons from assistive technology', () => {
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      const button = screen.getByRole('button', { name: 'Close' });
+      expect(button.querySelector('[aria-hidden="true"]')).not.toBeNull();
+      expect(within(button).queryByRole('img')).toBeNull();
+    });
+
+    it('exposes aria-pressed on the overlay toggle only', async () => {
+      const user = userEvent.setup();
+      render(
+        <PhotoViewer
+          selectedImage={overlayImage}
+          images={[overlayImage]}
+          onClose={jest.fn()}
+          settings={{ showOverlayButton: true }}
+        />,
+      );
+
+      const toggle = screen.getByRole('button', { name: 'Toggle overlay' });
+      expect(toggle).toHaveAttribute('aria-pressed', 'false');
+      expect(screen.getByRole('button', { name: 'Close' })).not.toHaveAttribute('aria-pressed');
+
+      await user.click(toggle);
+      expect(screen.getByRole('button', { name: 'Toggle overlay' })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+
+    it('brightens the control bar while focus is inside it', () => {
+      const { container } = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+      const nav = container.querySelector('.photo-viewer-navigation') as HTMLElement;
+
+      expect(nav).toHaveStyle({ backgroundColor: 'rgba(0, 0, 0, 0.5)' });
+
+      act(() => screen.getByRole('button', { name: 'Close' }).focus());
+      expect(nav).toHaveStyle({ backgroundColor: 'rgba(0, 0, 0, 0.8)' });
+    });
+  });
+
+  describe('labels', () => {
+    it('applies overrides and keeps defaults for unspecified keys', () => {
+      render(
+        <PhotoViewer
+          selectedImage={images[0]}
+          images={images}
+          onClose={jest.fn()}
+          labels={{ close: 'Bezár' }}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: 'Bezár' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Zoom in' })).toBeInTheDocument();
+    });
+
+    it('names the dialog from the image title, then the dialog label', () => {
+      const { rerender } = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+      expect(screen.getByRole('dialog')).toHaveAccessibleName('Photo viewer');
+
+      rerender(
+        <PhotoViewer
+          selectedImage={images[0]}
+          images={images}
+          onClose={jest.fn()}
+          labels={{ dialog: 'Képnéző' }}
+        />,
+      );
+      expect(screen.getByRole('dialog')).toHaveAccessibleName('Képnéző');
+
+      rerender(
+        <PhotoViewer
+          selectedImage={{ ...images[0], title: 'Sunset' }}
+          images={images}
+          onClose={jest.fn()}
+          labels={{ dialog: 'Képnéző' }}
+        />,
+      );
+      expect(screen.getByRole('dialog')).toHaveAccessibleName('Sunset');
+    });
+  });
+
+  describe('keyboard operability', () => {
+    it('activates a control with Enter', async () => {
+      const user = userEvent.setup();
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      act(() => screen.getByRole('button', { name: 'Zoom in' }).focus());
+      await user.keyboard('{Enter}');
+
+      // Reset only renders once the transform differs from its default.
+      expect(
+        await screen.findByRole('button', { name: 'Reset zoom and rotation' }),
+      ).toBeInTheDocument();
+    });
+
+    it('activates a control with Space', async () => {
+      const user = userEvent.setup();
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      act(() => screen.getByRole('button', { name: 'Zoom in' }).focus());
+      await user.keyboard(' ');
+
+      expect(
+        await screen.findByRole('button', { name: 'Reset zoom and rotation' }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not close the viewer when a control is clicked', async () => {
+      const user = userEvent.setup();
+      const onClose = jest.fn();
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={onClose} />);
+
+      await user.click(screen.getByRole('button', { name: 'Zoom in' }));
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('focus trap', () => {
+    it('moves focus to the dialog on open', () => {
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      expect(screen.getByRole('dialog')).toHaveFocus();
+    });
+
+    it('tabs from the dialog to the first control', async () => {
+      const user = userEvent.setup();
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      await user.tab();
+
+      expect(screen.getByRole('button', { name: 'Previous image' })).toHaveFocus();
+    });
+
+    it('wraps forward from the last control to the first', async () => {
+      const user = userEvent.setup();
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      act(() => screen.getByRole('button', { name: 'Close' }).focus());
+      await user.tab();
+
+      expect(screen.getByRole('button', { name: 'Previous image' })).toHaveFocus();
+    });
+
+    it('wraps backward from the first control to the last', async () => {
+      const user = userEvent.setup();
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      act(() => screen.getByRole('button', { name: 'Previous image' }).focus());
+      await user.tab({ shift: true });
+
+      expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+    });
+
+    it('never lets focus reach content behind the dialog', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <button>outside</button>
+          <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />
+        </>,
+      );
+
+      const outside = screen.getByRole('button', { name: 'outside' });
+      const dialog = screen.getByRole('dialog');
+
+      for (let i = 0; i < DEFAULT_CONTROL_NAMES.length + 2; i += 1) {
+        await user.tab();
+        expect(outside).not.toHaveFocus();
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      }
+    });
+
+    it('pulls focus back when something outside steals it', () => {
+      render(
+        <>
+          <button>outside</button>
+          <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />
+        </>,
+      );
+
+      screen.getByRole('button', { name: 'outside' }).focus();
+
+      expect(screen.getByRole('dialog')).toHaveFocus();
+    });
+
+    it('recovers when the focused control unmounts itself', async () => {
+      const user = userEvent.setup();
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+
+      await user.click(screen.getByRole('button', { name: 'Zoom in' }));
+      const reset = await screen.findByRole('button', { name: 'Reset zoom and rotation' });
+
+      // Resetting removes this very button from the DOM. Browsers and jsdom
+      // move focus to <body> without firing focusin, so only the focusout
+      // path can recover here.
+      act(() => reset.focus());
+      await user.click(reset);
+
+      expect(
+        screen.queryByRole('button', { name: 'Reset zoom and rotation' }),
+      ).not.toBeInTheDocument();
+      // Recovery is deferred to a microtask so React's commit lands first.
+      await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus());
+
+      await user.tab();
+      expect(screen.getByRole('button', { name: 'Previous image' })).toHaveFocus();
+    });
+
+    it('does not trap focus while closed', () => {
+      render(
+        <>
+          <button>outside</button>
+          <PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />
+        </>,
+      );
+
+      const outside = screen.getByRole('button', { name: 'outside' });
+      outside.focus();
+
+      expect(outside).toHaveFocus();
+    });
+  });
+
+  describe('focus restore', () => {
+    it('returns focus to the element that opened the viewer', async () => {
+      const user = userEvent.setup();
+
+      function Harness() {
+        const [open, setOpen] = useState(false);
+        return (
+          <>
+            <button onClick={() => setOpen(true)}>Open</button>
+            <PhotoViewer
+              selectedImage={open ? images[0] : null}
+              images={images}
+              onClose={() => setOpen(false)}
+              // Isolates this from useClickOutsideToClose, whose window-level
+              // mousedown handler would otherwise fire on the trigger click.
+              settings={{ clickOutsideToExit: false }}
+            />
+          </>
+        );
+      }
+
+      render(<Harness />);
+      const trigger = screen.getByRole('button', { name: 'Open' });
+
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toHaveFocus();
+
+      await user.keyboard('{Escape}');
+
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  describe('body scroll lock', () => {
+    it('locks while open and restores the previous value on close', () => {
+      document.body.style.overflow = 'scroll';
+
+      const { rerender } = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+      expect(document.body.style.overflow).toBe('hidden');
+
+      rerender(<PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />);
+      expect(document.body.style.overflow).toBe('scroll');
+    });
+
+    it('restores on unmount', () => {
+      document.body.style.overflow = 'scroll';
+
+      const { unmount } = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+      expect(document.body.style.overflow).toBe('hidden');
+
+      unmount();
+      expect(document.body.style.overflow).toBe('scroll');
+    });
+
+    it('does not lock while closed', () => {
+      document.body.style.overflow = 'scroll';
+
+      render(<PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />);
+
+      expect(document.body.style.overflow).toBe('scroll');
+    });
+
+    it('stays locked until the last open viewer unmounts', () => {
+      document.body.style.overflow = 'scroll';
+
+      const first = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+      const second = render(
+        <PhotoViewer selectedImage={images[1]} images={images} onClose={jest.fn()} />,
+      );
+      expect(document.body.style.overflow).toBe('hidden');
+
+      first.unmount();
+      expect(document.body.style.overflow).toBe('hidden');
+
+      second.unmount();
+      expect(document.body.style.overflow).toBe('scroll');
+    });
+  });
+});

--- a/src/components/photo-viewer/types.ts
+++ b/src/components/photo-viewer/types.ts
@@ -1,3 +1,24 @@
+/**
+ * Accessible names for the viewer and its controls.
+ *
+ * Keys are per control rather than per icon: previous/next and rotate
+ * left/right share an icon component and differ only by a CSS transform.
+ */
+export type PhotoViewerLabels = {
+  /** Falls back to the image title when one is set. */
+  dialog: string;
+  close: string;
+  previous: string;
+  next: string;
+  zoomIn: string;
+  zoomOut: string;
+  rotateLeft: string;
+  rotateRight: string;
+  reset: string;
+  download: string;
+  toggleOverlay: string;
+};
+
 export type PhotoViewerSettings = {
   allowZoom: boolean;
   allowRotate: boolean;

--- a/src/hooks/photo-viewer/useBodyScrollLock.ts
+++ b/src/hooks/photo-viewer/useBodyScrollLock.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+
+/**
+ * Module-level so that nested or sibling viewers cannot unlock each other.
+ *
+ * Saving only on the 0 -> 1 transition avoids a second viewer recording the
+ * first one's `hidden` as the value to restore, which would leave the page
+ * unscrollable for good. Restoring only on the return to 0 keeps the lock in
+ * place while any viewer is still open.
+ */
+let lockCount = 0;
+let savedOverflow: string | null = null;
+let savedPaddingRight: string | null = null;
+
+export function useBodyScrollLock({ enabled }: { enabled: boolean }): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const body = document.body;
+
+    if (lockCount === 0) {
+      savedOverflow = body.style.overflow;
+      savedPaddingRight = body.style.paddingRight;
+
+      // Replace the width the scrollbar was occupying, so the page behind the
+      // backdrop does not jump sideways when it disappears.
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      if (scrollbarWidth > 0) {
+        const current = parseFloat(window.getComputedStyle(body).paddingRight) || 0;
+        body.style.paddingRight = `${current + scrollbarWidth}px`;
+      }
+
+      body.style.overflow = 'hidden';
+    }
+    lockCount += 1;
+
+    return () => {
+      lockCount -= 1;
+      if (lockCount > 0) return;
+
+      body.style.overflow = savedOverflow ?? '';
+      body.style.paddingRight = savedPaddingRight ?? '';
+      savedOverflow = null;
+      savedPaddingRight = null;
+    };
+  }, [enabled]);
+}

--- a/src/hooks/photo-viewer/useFocusTrap.ts
+++ b/src/hooks/photo-viewer/useFocusTrap.ts
@@ -1,0 +1,151 @@
+import { useEffect, useRef } from 'react';
+import { getFocusableElements } from '../../utils/photo-viewer/focusable';
+
+/**
+ * Only the most recently mounted trap acts. Without this, two open viewers
+ * would each pull focus back into their own container inside a single
+ * synchronous `focusin` dispatch and overflow the stack.
+ */
+const trapStack: symbol[] = [];
+
+/**
+ * Confines Tab focus to `containerRef` while `enabled`, and restores focus to
+ * whatever was focused beforehand on cleanup.
+ *
+ * The container is expected to carry `tabIndex={-1}` so it can receive focus
+ * itself; `getFocusableElements` filters it back out of the Tab cycle.
+ */
+export function useFocusTrap({
+  enabled,
+  containerRef,
+}: {
+  enabled: boolean;
+  containerRef: React.RefObject<HTMLElement | null>;
+}): void {
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const id = Symbol('zz-focus-trap');
+    trapStack.push(id);
+    const isTopMost = () => trapStack[trapStack.length - 1] === id;
+
+    const active = document.activeElement as HTMLElement | null;
+    // Skip when the container already holds focus, so StrictMode's second
+    // effect pass does not record the dialog as its own restore target.
+    if (active && active !== document.body && !container.contains(active)) {
+      previousFocusRef.current = active;
+    }
+
+    container.focus({ preventScroll: true });
+
+    const focusFirstOrLast = (backwards: boolean) => {
+      const items = getFocusableElements(container);
+      if (items.length === 0) {
+        container.focus({ preventScroll: true });
+        return;
+      }
+      (backwards ? items[items.length - 1] : items[0]).focus({ preventScroll: true });
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!enabledRef.current || !isTopMost() || e.key !== 'Tab') return;
+      if (!container.isConnected) return;
+
+      const items = getFocusableElements(container);
+      if (items.length === 0) {
+        e.preventDefault();
+        container.focus({ preventScroll: true });
+        return;
+      }
+
+      const current = document.activeElement as HTMLElement | null;
+      const index = current ? items.indexOf(current) : -1;
+
+      // Focus sits on the container, on `<body>`, or outside the dialog.
+      if (index === -1) {
+        e.preventDefault();
+        focusFirstOrLast(e.shiftKey);
+        return;
+      }
+
+      const atStart = e.shiftKey && index === 0;
+      const atEnd = !e.shiftKey && index === items.length - 1;
+      if (atStart || atEnd) {
+        e.preventDefault();
+        focusFirstOrLast(e.shiftKey);
+      }
+      // Interior tabs are left to the browser.
+    };
+
+    const onFocusIn = (e: FocusEvent) => {
+      if (!enabledRef.current || !isTopMost() || !container.isConnected) return;
+      const target = e.target as Node | null;
+      // Cannot loop: refocusing the container re-fires `focusin` with the
+      // container as target, which this check short-circuits.
+      if (target && container.contains(target)) return;
+      container.focus({ preventScroll: true });
+    };
+
+    /** Pull focus back to the container if it has ended up nowhere useful. */
+    const recoverStrayFocus = () => {
+      if (!enabledRef.current || !isTopMost() || !container.isConnected) return;
+      const current = document.activeElement;
+      if (current && current !== document.body && container.contains(current)) return;
+      container.focus({ preventScroll: true });
+    };
+
+    const onFocusOut = (e: FocusEvent) => {
+      if (!enabledRef.current || !isTopMost()) return;
+      // Focus moved somewhere real; `focusin` is the authority.
+      if (e.relatedTarget) return;
+      // Defer so React's commit lands before we look at `activeElement`.
+      queueMicrotask(recoverStrayFocus);
+    };
+
+    /**
+     * Removing the focused element fires no focus event at all. Neither
+     * browsers nor jsdom emit `focusout` or `focusin`; `activeElement` just
+     * becomes `<body>`. This is reachable in a few keystrokes, since Reset
+     * unmounts itself once the transform returns to its default, so watching
+     * the DOM is the only way to catch it.
+     */
+    const observer = new MutationObserver(() => {
+      if (!enabledRef.current || !isTopMost()) return;
+      const current = document.activeElement;
+      if (current && current !== document.body && container.contains(current)) return;
+      queueMicrotask(recoverStrayFocus);
+    });
+    observer.observe(container, { childList: true, subtree: true });
+
+    document.addEventListener('keydown', onKeyDown, true);
+    document.addEventListener('focusin', onFocusIn);
+    container.addEventListener('focusout', onFocusOut);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener('keydown', onKeyDown, true);
+      document.removeEventListener('focusin', onFocusIn);
+      container.removeEventListener('focusout', onFocusOut);
+
+      const index = trapStack.indexOf(id);
+      if (index !== -1) trapStack.splice(index, 1);
+
+      const previous = previousFocusRef.current;
+      previousFocusRef.current = null;
+      if (!previous || !previous.isConnected) return;
+
+      // Something else legitimately took focus while closing; leave it alone.
+      const current = document.activeElement;
+      if (current && current !== document.body && document.contains(current)) return;
+
+      previous.focus({ preventScroll: true });
+    };
+  }, [enabled, containerRef]);
+}

--- a/src/hooks/photo-viewer/usePhotoViewerLabels.ts
+++ b/src/hooks/photo-viewer/usePhotoViewerLabels.ts
@@ -1,0 +1,6 @@
+import type { PhotoViewerLabels } from '../../components/photo-viewer/types';
+import { DEFAULT_PHOTO_VIEWER_LABELS } from '../../utils/photo-viewer/constants';
+
+export function usePhotoViewerLabels(overrides: Partial<PhotoViewerLabels>): PhotoViewerLabels {
+  return { ...DEFAULT_PHOTO_VIEWER_LABELS, ...overrides };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 export { PhotoViewer } from './components/photo-viewer/PhotoViewer';
-export type { PhotoViewerProps } from './components/photo-viewer/PhotoViewer';
+export type {
+  PhotoViewerProps,
+  PhotoViewerLabels,
+  PhotoViewerSettings,
+} from './components/photo-viewer/PhotoViewer';
 export { Gallery } from './components/gallery/Gallery';
 export { ImageCarousel } from './components/image-carousel/ImageCarousel';
 export type { ImageCarouselProps } from './components/image-carousel/ImageCarousel';

--- a/src/utils/photo-viewer/__tests__/focusable.test.ts
+++ b/src/utils/photo-viewer/__tests__/focusable.test.ts
@@ -1,0 +1,58 @@
+import { getFocusableElements } from '../focusable';
+
+function mount(html: string): HTMLElement {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('getFocusableElements', () => {
+  it('returns focusable descendants in document order', () => {
+    const container = mount(`
+      <button id="a"></button>
+      <a id="b" href="#x"></a>
+      <input id="c" />
+    `);
+
+    expect(getFocusableElements(container).map((el) => el.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('skips disabled controls', () => {
+    const container = mount('<button id="a"></button><button id="b" disabled></button>');
+
+    expect(getFocusableElements(container).map((el) => el.id)).toEqual(['a']);
+  });
+
+  it('skips tabindex="-1", including a trap container that carries it', () => {
+    const container = mount('<div id="inner" tabindex="-1"></div><button id="a"></button>');
+    container.setAttribute('tabindex', '-1');
+
+    expect(getFocusableElements(container).map((el) => el.id)).toEqual(['a']);
+  });
+
+  it('skips elements inside an aria-hidden subtree', () => {
+    const container = mount(`
+      <div aria-hidden="true"><button id="hidden"></button></div>
+      <button id="a"></button>
+    `);
+
+    expect(getFocusableElements(container).map((el) => el.id)).toEqual(['a']);
+  });
+
+  it('skips [hidden] elements', () => {
+    const container = mount('<button id="a"></button><button id="b" hidden></button>');
+
+    expect(getFocusableElements(container).map((el) => el.id)).toEqual(['a']);
+  });
+
+  it('returns an empty array when nothing is focusable', () => {
+    const container = mount('<div></div><span></span>');
+
+    expect(getFocusableElements(container)).toEqual([]);
+  });
+});

--- a/src/utils/photo-viewer/constants.ts
+++ b/src/utils/photo-viewer/constants.ts
@@ -1,4 +1,4 @@
-import type { PhotoViewerSettings } from '../../components/photo-viewer/types';
+import type { PhotoViewerLabels, PhotoViewerSettings } from '../../components/photo-viewer/types';
 
 export const DEFAULT_ZOOM_STEP = 0.3;
 export const DEFAULT_LARGE_ZOOM = 4;
@@ -22,3 +22,19 @@ export const DEFAULT_PHOTO_VIEWER_SETTINGS: PhotoViewerSettings = {
 };
 
 export const EMPTY_PHOTO_VIEWER_SETTINGS: Partial<PhotoViewerSettings> = {};
+
+export const DEFAULT_PHOTO_VIEWER_LABELS: PhotoViewerLabels = {
+  dialog: 'Photo viewer',
+  close: 'Close',
+  previous: 'Previous image',
+  next: 'Next image',
+  zoomIn: 'Zoom in',
+  zoomOut: 'Zoom out',
+  rotateLeft: 'Rotate left',
+  rotateRight: 'Rotate right',
+  reset: 'Reset zoom and rotation',
+  download: 'Download image',
+  toggleOverlay: 'Toggle overlay',
+};
+
+export const EMPTY_PHOTO_VIEWER_LABELS: Partial<PhotoViewerLabels> = {};

--- a/src/utils/photo-viewer/focusable.ts
+++ b/src/utils/photo-viewer/focusable.ts
@@ -1,0 +1,38 @@
+export const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  'audio[controls]',
+  'video[controls]',
+  'summary',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]',
+].join(',');
+
+/**
+ * Focusable descendants of `container`, in document order.
+ *
+ * Deliberately does not filter on visibility. The usual `offsetParent` /
+ * `getClientRects()` checks report every element as hidden under jsdom, which
+ * has no layout engine, so adding one would silently empty the focus trap in
+ * tests while still working in a browser. Everything inside the viewer is
+ * library-controlled, so there is nothing invisible to filter out.
+ */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  const nodes = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+
+  return nodes.filter(
+    (el) =>
+      // Drops `tabindex="-1"`, including the dialog container itself.
+      el.tabIndex >= 0 &&
+      !el.hasAttribute('disabled') &&
+      !el.hasAttribute('hidden') &&
+      !el.closest('[aria-hidden="true"]'),
+  );
+}


### PR DESCRIPTION
## Summary

Every PhotoViewer control rendered as a `<div onClick>` with no `role`, no `tabIndex` and no accessible name, while the dialog advertised `aria-modal="true"` with **zero focusable children**, no focus trap, no focus restore and no scroll lock. The flagship component was unusable without a mouse and invisible to screen readers.

Appearance, existing props, and the zero-runtime-dependency guarantee are unchanged. The focus trap is hand-rolled.

## Changes

- **Real buttons.** `NavigationActionButton` renders `<button type="button">` with an `aria-label`. `label` is a **required** prop, so all ten call sites are named at compile time. Icons are wrapped in an `aria-hidden` span, which avoids touching the eight icon components.
- **Focus trap** (`useFocusTrap`): focus moves to the dialog on open, Tab/Shift+Tab cycle within it, and focus is restored to the opening element on close.
- **Scroll lock** (`useBodyScrollLock`): refcounted so nested viewers cannot unlock each other, with scrollbar-width compensation so the page behind does not shift.
- **`aria-pressed`** on the overlay toggle, which previously showed its state only as a background colour.
- **Focus brightens the control bar**, which was previously hover-only, leaving keyboard users on a permanently dimmed bar.
- **`labels` prop** for translating accessible names, with `PhotoViewerLabels` exported. Unspecified keys keep their English defaults. Also exports `PhotoViewerSettings`, already a public prop type but unreachable from the package root.

## Three non-obvious details

**Both new hooks are gated on an explicit `isOpen` flag.** Hooks run above PhotoViewer's `if (!selectedImage || !currentImage) return null`, so an ungated trap or lock would capture focus and freeze page scrolling for a mounted-but-closed viewer rendering nothing. There is a test for each.

**Focus recovery uses a MutationObserver, not focus events.** I originally used `focusout`, and it did not work. Removing the focused element fires *no* focus event at all, in browsers or jsdom; `activeElement` silently becomes `<body>`. I confirmed this with an instrumented run that logged an empty event list. This is reachable in about three keystrokes, since Reset unmounts itself once the transform returns to its default, so watching the DOM is the only reliable trigger.

**The button reset lives in the stylesheet, not inline.** The old `<div>` had no inline background, which is the only reason `.nav-action-button:hover` applied. Adding `backgroundColor: 'transparent'` inline to reset the button would have outranked the hover and focus rules on specificity and silently killed them.

`getFocusableElements` also deliberately omits a visibility filter: `offsetParent`/`getClientRects` report everything as hidden under jsdom, which would empty the trap in tests while still passing in a browser. There is a comment saying so.

## Verification

**50 tests pass** (21 before), including a regression test that clicking a control does not close the viewer, which guards the `nav-action-button` class that `useClickOutsideToClose` depends on by name.

Driven by keyboard in a real browser (Storybook), since jsdom cannot prove any of this:

- All 8 controls are `<button type="button">` with correct labels.
- Tab from the dialog reaches the first control with a genuine `2px solid white` ring and `:focus-visible` matching.
- Tabbing through all 8 wraps back to the first and never escapes into the Storybook UI around it.
- Activating Reset while focused unmounts it; focus lands back on the dialog and the next Tab re-enters the controls.
- `body` gets `overflow: hidden` and `padding-right: 15px` against a real scrollbar; Escape restores both to their originals.
- Opening from a trigger button and pressing Escape returns focus to that exact button.

**Not verified in-browser:** Enter/Space activation. The automation harness delivered the `keydown` into the page but the browser did not perform native button activation from the synthetic event, so no click was produced. This is a harness limitation, not a code path: the elements are native buttons, and nothing in our code intercepts Enter (the trap handler returns early for any key other than Tab, and `useKeyboardShortcuts` has no Enter case and never calls `preventDefault`). Enter and Space are covered by user-event tests instead.

`yarn install --frozen-lockfile` verified locally, since `@testing-library/user-event` was already resolved in the lockfile as a transitive Storybook dependency.

## Known limitation, not addressed here

PhotoViewer is not portaled, so a screen reader's virtual cursor can still walk sibling content behind the modal. `aria-modal="true"` covers this on modern screen reader and browser pairs; the complete fix needs a portal plus `inert` on siblings, which is a much larger change. I would not consider the screen-reader criterion fully closed without it, and am happy to file a follow-up.

Closes #27