### PR TITLE
fix(build): emit real source maps by enabling tsconfig sourceMap

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "react",
     "declaration": true,
     "declarationDir": "dist/types",
+    "sourceMap": true,
     "strict": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary
The published source maps were empty and unusable. The rollup config emits `sourcemap: true` for both bundles, but `tsconfig.json` never enabled `sourceMap`, so `rollup-plugin-typescript2` passed rollup no mapping data. The shipped `dist/index.js.map` / `dist/index.mjs.map` had an empty `sources` array and all-semicolon `mappings`.

This is in the packaging area modernized in #35: the outputs claimed to ship source maps that didn't actually map anything.

## Changes
- Enable `"sourceMap": true` in `tsconfig.json`, producing complete maps (47 sources with content and real mappings) for both the CJS and ESM bundles.

Verified: `tsc --noEmit` clean, all 50 tests pass, both `.map` outputs now contain real sources and mappings.