### PR TITLE
fix(PhotoViewer): restore focus to the opener under StrictMode

### DIFF
--- a/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
+++ b/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
@@ -285,27 +285,66 @@ describe('PhotoViewer accessibility', () => {
   });
 
   describe('focus restore', () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open</button>
+          <PhotoViewer
+            selectedImage={open ? images[0] : null}
+            images={images}
+            onClose={() => setOpen(false)}
+            // Isolates this from useClickOutsideToClose, whose window-level
+            // mousedown handler would otherwise fire on the trigger click.
+            settings={{ clickOutsideToExit: false }}
+          />
+        </>
+      );
+    }
+
     it('returns focus to the element that opened the viewer', async () => {
       const user = userEvent.setup();
 
-      function Harness() {
+      render(<Harness />);
+      const trigger = screen.getByRole('button', { name: 'Open' });
+
+      await user.click(trigger);
+      expect(screen.getByRole('dialog')).toHaveFocus();
+
+      await user.keyboard('{Escape}');
+
+      expect(trigger).toHaveFocus();
+    });
+
+    it('restores focus under StrictMode, whose setup/cleanup/setup remount must not discard the opener', async () => {
+      const user = userEvent.setup();
+
+      // Mounts the viewer on open (rather than keeping it mounted and toggling
+      // `selectedImage`), so its focus-trap effect mounts already enabled. That
+      // is the only path where StrictMode double-invokes setup/cleanup/setup,
+      // and where an eagerly-cleared restore target is lost.
+      function MountHarness() {
         const [open, setOpen] = useState(false);
         return (
           <>
             <button onClick={() => setOpen(true)}>Open</button>
-            <PhotoViewer
-              selectedImage={open ? images[0] : null}
-              images={images}
-              onClose={() => setOpen(false)}
-              // Isolates this from useClickOutsideToClose, whose window-level
-              // mousedown handler would otherwise fire on the trigger click.
-              settings={{ clickOutsideToExit: false }}
-            />
+            {open && (
+              <PhotoViewer
+                selectedImage={images[0]}
+                images={images}
+                onClose={() => setOpen(false)}
+                settings={{ clickOutsideToExit: false }}
+              />
+            )}
           </>
         );
       }
 
-      render(<Harness />);
+      render(
+        <React.StrictMode>
+          <MountHarness />
+        </React.StrictMode>,
+      );
       const trigger = screen.getByRole('button', { name: 'Open' });
 
       await user.click(trigger);

--- a/src/hooks/photo-viewer/useFocusTrap.ts
+++ b/src/hooks/photo-viewer/useFocusTrap.ts
@@ -138,13 +138,21 @@ export function useFocusTrap({
       if (index !== -1) trapStack.splice(index, 1);
 
       const previous = previousFocusRef.current;
-      previousFocusRef.current = null;
-      if (!previous || !previous.isConnected) return;
+      if (!previous || !previous.isConnected) {
+        previousFocusRef.current = null;
+        return;
+      }
 
-      // Something else legitimately took focus while closing; leave it alone.
+      // Something else legitimately holds focus, so leave it alone. This also
+      // covers StrictMode's mount cleanup, where the dialog is still mounted
+      // and focused: clearing the target here would discard the opener before
+      // the second mount pass (which no longer re-records it, seeing the dialog
+      // already focused), so the real close later restores nothing. Keep the
+      // target and only clear it once we actually restore.
       const current = document.activeElement;
       if (current && current !== document.body && document.contains(current)) return;
 
+      previousFocusRef.current = null;
       previous.focus({ preventScroll: true });
     };
   }, [enabled, containerRef]);


### PR DESCRIPTION
## Summary
`useFocusTrap` failed to return focus to the element that opened the viewer under React StrictMode. This defeats the hook's own stated StrictMode-correctness goal from #37.

The cleanup nulled `previousFocusRef` **before** the guard that decides whether to restore. When the trap mounts already enabled (the common pattern of conditionally mounting the viewer on open), StrictMode's setup → cleanup → setup cycle runs with the dialog still mounted and focused: the cleanup skips restoration but has already discarded the opener, and the second setup does not re-record it (it sees the dialog focused). On the real close, focus falls to `<body>` instead of the opener.

The existing focus-restore test missed this because it keeps the viewer mounted and toggles `selectedImage`, so `enabled` flips via a dependency change, which StrictMode does not double-invoke.

## Changes
- Clear the saved restore target only when a restore actually happens, so the StrictMode remount preserves it.
- Add a StrictMode focus-restore test that mounts the viewer on open (the path that triggers the double-invoke).

Verified: `tsc --noEmit` clean, all 51 tests pass (new test fails before the fix, passes after).