### PR TITLE
ci: run release only on the release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - release
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -33,6 +33,10 @@ jobs:
           version: yarn version-packages
           publish: yarn release
         env:
+          # Skip Husky git hooks: the changesets action creates a bot
+          # "Version Packages" commit that intentionally isn't a
+          # conventional commit, so commitlint (commit-msg) would reject it.
+          HUSKY: "0"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary
The Release workflow ran on every push to `main` and failed each time. `changesets/action` creates a bot "Version Packages" commit that is intentionally not a conventional commit, and the local Husky `commit-msg` hook (commitlint) rejected it, aborting the release. This scopes the workflow to a dedicated `release` branch and stops the git hooks from interfering with the bot commit.

## Changes
- Trigger the Release workflow on pushes to `release` instead of `main`.
- Set `HUSKY=0` on the changesets step so the automated commit isn't blocked by local git hooks meant for human commits.