### PR TITLE
feat: report download fallback results

### DIFF
--- a/.changeset/quiet-brooms-tap.md
+++ b/.changeset/quiet-brooms-tap.md
@@ -1,0 +1,13 @@
+---
+'zimme-zoom': minor
+---
+
+Expose download fallback results from PhotoViewer.
+
+Adds an optional `onDownloadFallback` prop that receives the final download
+result when canvas or fetch download attempts fail and the viewer falls back to
+another method. `downloadImage` now returns the method used plus the failed
+fallback attempts, while preserving the existing default fallback behavior.
+
+Canvas conversion returning `null` is now recorded as a canvas fallback failure
+instead of silently continuing to the next method.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ All components are exported from the main package:
 
 ```tsx
 import { PhotoViewer, Gallery, MediaGrid, Image } from 'zimme-zoom';
-import type { ZZImage, PhotoViewerProps, MediaGridItem, MediaGridProps } from 'zimme-zoom';
+import type {
+  DownloadImageResult,
+  MediaGridItem,
+  MediaGridProps,
+  PhotoViewerProps,
+  ZZImage,
+} from 'zimme-zoom';
 ```
 
 ## Demo
@@ -111,14 +117,21 @@ The `settings` prop allows you to customize the PhotoViewer behavior. All settin
 
 #### PhotoViewer Props
 
-| Prop            | Type                           | Required | Description                                                                            |
-| --------------- | ------------------------------ | -------- | -------------------------------------------------------------------------------------- |
-| `images`        | `ZZImage[]`                    | Yes      | Array of images to display                                                             |
-| `selectedImage` | `ZZImage \| null`              | Yes      | Currently selected image to display                                                    |
-| `onClose`       | `() => void`                   | Yes      | Callback function called when PhotoViewer is closed                                    |
-| `onImageChange` | `(image: ZZImage) => void`     | No       | Callback function called when the displayed image changes                              |
-| `settings`      | `Partial<PhotoViewerSettings>` | No       | Configuration object for PhotoViewer behavior (see [Settings](#available-settings))    |
-| `labels`        | `Partial<PhotoViewerLabels>`   | No       | Accessible names for the dialog and its controls (see [Accessibility](#accessibility)) |
+| Prop                 | Type                                    | Required | Description                                                                            |
+| -------------------- | --------------------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| `images`             | `ZZImage[]`                             | Yes      | Array of images to display                                                             |
+| `selectedImage`      | `ZZImage \| null`                       | Yes      | Currently selected image to display                                                    |
+| `onClose`            | `() => void`                            | Yes      | Callback function called when PhotoViewer is closed                                    |
+| `onImageChange`      | `(image: ZZImage) => void`              | No       | Callback function called when the displayed image changes                              |
+| `onDownloadFallback` | `(result: DownloadImageResult) => void` | No       | Called when image download falls back after canvas or fetch fails                      |
+| `settings`           | `Partial<PhotoViewerSettings>`          | No       | Configuration object for PhotoViewer behavior (see [Settings](#available-settings))    |
+| `labels`             | `Partial<PhotoViewerLabels>`            | No       | Accessible names for the dialog and its controls (see [Accessibility](#accessibility)) |
+
+When `allowDownload` is enabled, PhotoViewer first tries a canvas download, then
+`fetch`, then opens the image in a new tab as a last resort for cross-origin
+images. Use `onDownloadFallback` to inspect the final method and failed attempts
+when one method fails and PhotoViewer has to fall back. A fallback can still
+finish with a successful download, such as canvas failing and `fetch` succeeding.
 
 #### Accessibility
 

--- a/src/components/photo-viewer/PhotoViewer.tsx
+++ b/src/components/photo-viewer/PhotoViewer.tsx
@@ -4,6 +4,7 @@ import PhotoViewerImage from './PhotoViewerImage';
 import type { PhotoViewerLabels, PhotoViewerSettings } from './types';
 import { ZZImage } from '../../types/image.type';
 import { downloadImage } from '../../utils/downloadImage';
+import type { DownloadImageResult } from '../../utils/downloadImage';
 import {
   EMPTY_PHOTO_VIEWER_LABELS,
   EMPTY_PHOTO_VIEWER_SETTINGS,
@@ -22,12 +23,18 @@ import { useTransform } from '../../hooks/photo-viewer/useTransform';
 import { useWheelZoom } from '../../hooks/photo-viewer/useWheelZoom';
 
 export type { PhotoViewerLabels, PhotoViewerSettings } from './types';
+export type {
+  DownloadImageError,
+  DownloadImageMethod,
+  DownloadImageResult,
+} from '../../utils/downloadImage';
 
 export type PhotoViewerProps = {
   selectedImage: ZZImage | null;
   images: ZZImage[];
   onClose: () => void;
   onImageChange?: (image: ZZImage) => void;
+  onDownloadFallback?: (result: DownloadImageResult) => void;
   settings?: Partial<PhotoViewerSettings>;
   /** Accessible names, for translation. Unspecified keys keep their defaults. */
   labels?: Partial<PhotoViewerLabels>;
@@ -69,6 +76,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   images,
   onClose,
   onImageChange,
+  onDownloadFallback,
   settings = EMPTY_PHOTO_VIEWER_SETTINGS,
   labels: labelOverrides = EMPTY_PHOTO_VIEWER_LABELS,
 }) => {
@@ -151,8 +159,11 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const handleDownload = useCallback(async () => {
     if (!allowDownload || !currentImage) return;
     const filename = currentImage.title || currentImage.alt || 'image';
-    await downloadImage(currentImage.src, filename, imageRef.current);
-  }, [allowDownload, currentImage]);
+    const result = await downloadImage(currentImage.src, filename, imageRef.current);
+    if (result.errors.length > 0) {
+      onDownloadFallback?.(result);
+    }
+  }, [allowDownload, currentImage, onDownloadFallback]);
 
   const { isDragging, onMouseDown } = useMouseDrag({
     enabled: zoom > 1,

--- a/src/components/photo-viewer/__tests__/PhotoViewer.test.tsx
+++ b/src/components/photo-viewer/__tests__/PhotoViewer.test.tsx
@@ -1,9 +1,17 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PhotoViewer } from '../PhotoViewer';
 import type { ZZImage } from '../../../types/image.type';
+import { downloadImage } from '../../../utils/downloadImage';
+import type { DownloadImageResult } from '../../../utils/downloadImage';
+
+jest.mock('../../../utils/downloadImage', () => ({
+  downloadImage: jest.fn(),
+}));
+
+const mockedDownloadImage = downloadImage as jest.MockedFunction<typeof downloadImage>;
 
 const images: ZZImage[] = [
   { id: '1', src: 'https://example.com/1.jpg', alt: 'First image' },
@@ -22,6 +30,14 @@ function expectTransform(
 }
 
 describe('PhotoViewer', () => {
+  beforeEach(() => {
+    mockedDownloadImage.mockResolvedValue({ method: 'canvas', errors: [] });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders nothing when no image is selected', () => {
     const { container } = render(
       <PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />,
@@ -46,6 +62,56 @@ describe('PhotoViewer', () => {
     await user.keyboard('{Escape}');
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDownloadFallback when downloadImage reports a fallback', async () => {
+    const user = userEvent.setup();
+    const onDownloadFallback = jest.fn();
+    const result: DownloadImageResult = {
+      method: 'fetch',
+      errors: [
+        {
+          method: 'canvas',
+          fallbackMethod: 'fetch',
+          error: new Error('Canvas conversion failed'),
+        },
+      ],
+    };
+    mockedDownloadImage.mockResolvedValue(result);
+
+    render(
+      <PhotoViewer
+        selectedImage={images[0]}
+        images={images}
+        onClose={jest.fn()}
+        onDownloadFallback={onDownloadFallback}
+        settings={{ allowDownload: true }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Download image' }));
+
+    await waitFor(() => expect(onDownloadFallback).toHaveBeenCalledWith(result));
+  });
+
+  it('does not call onDownloadFallback when the download succeeds without fallback', async () => {
+    const user = userEvent.setup();
+    const onDownloadFallback = jest.fn();
+
+    render(
+      <PhotoViewer
+        selectedImage={images[0]}
+        images={images}
+        onClose={jest.fn()}
+        onDownloadFallback={onDownloadFallback}
+        settings={{ allowDownload: true }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Download image' }));
+
+    await waitFor(() => expect(mockedDownloadImage).toHaveBeenCalledTimes(1));
+    expect(onDownloadFallback).not.toHaveBeenCalled();
   });
 
   it('calls onClose when the close control is clicked', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 export { PhotoViewer } from './components/photo-viewer/PhotoViewer';
 export type {
+  DownloadImageError,
+  DownloadImageMethod,
+  DownloadImageResult,
   PhotoViewerProps,
   PhotoViewerLabels,
   PhotoViewerSettings,

--- a/src/utils/__tests__/downloadImage.test.ts
+++ b/src/utils/__tests__/downloadImage.test.ts
@@ -1,0 +1,154 @@
+import { downloadImage } from '../downloadImage';
+
+const mockLoadedImage = () => {
+  const image = document.createElement('img');
+  Object.defineProperties(image, {
+    complete: { value: true },
+    naturalWidth: { value: 100 },
+    naturalHeight: { value: 50 },
+  });
+  return image;
+};
+
+const mockCanvasDownload = (blob: Blob | null = new Blob(['canvas'])) => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: jest.fn(() => ({ drawImage: jest.fn() })),
+  });
+  Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+    configurable: true,
+    value: jest.fn((callback: BlobCallback) => callback(blob)),
+  });
+};
+
+describe('downloadImage', () => {
+  let clickSpy: jest.SpiedFunction<HTMLAnchorElement['click']>;
+  let consoleWarnSpy: jest.SpiedFunction<typeof console.warn>;
+  let createObjectURL: jest.MockedFunction<(blob: Blob | MediaSource) => string>;
+  let revokeObjectURL: jest.MockedFunction<(url: string) => void>;
+
+  beforeEach(() => {
+    clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    createObjectURL = jest.fn((_blob: Blob | MediaSource) => 'blob:download');
+    revokeObjectURL = jest.fn((_url: string) => undefined);
+
+    Object.defineProperty(window.URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(window.URL, 'revokeObjectURL', {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('downloads with canvas when the loaded image can be drawn', async () => {
+    mockCanvasDownload();
+    const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+    global.fetch = fetchMock;
+
+    const result = await downloadImage(
+      'https://example.com/photo.jpg',
+      'photo.jpg',
+      mockLoadedImage(),
+    );
+
+    expect(result).toEqual({ method: 'canvas', errors: [] });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:download');
+  });
+
+  it('reports a canvas failure before falling back to fetch', async () => {
+    const canvasError = new Error('tainted canvas');
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: jest.fn(() => {
+        throw canvasError;
+      }),
+    });
+    const response = {
+      ok: true,
+      blob: jest.fn().mockResolvedValue(new Blob(['fetch'])),
+    } as unknown as Response;
+    const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValue(response);
+    global.fetch = fetchMock;
+
+    const result = await downloadImage(
+      'https://example.com/photo.jpg',
+      'photo.jpg',
+      mockLoadedImage(),
+    );
+
+    expect(result).toEqual({
+      method: 'fetch',
+      errors: [{ method: 'canvas', fallbackMethod: 'fetch', error: canvasError }],
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Canvas download failed, trying fetch:',
+      canvasError,
+    );
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a canvas failure when toBlob yields no blob before falling back to fetch', async () => {
+    mockCanvasDownload(null);
+    const response = {
+      ok: true,
+      blob: jest.fn().mockResolvedValue(new Blob(['fetch'])),
+    } as unknown as Response;
+    const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValue(response);
+    global.fetch = fetchMock;
+
+    const result = await downloadImage(
+      'https://example.com/photo.jpg',
+      'photo.jpg',
+      mockLoadedImage(),
+    );
+
+    expect(result.method).toBe('fetch');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].method).toBe('canvas');
+    expect(result.errors[0].fallbackMethod).toBe('fetch');
+    expect(result.errors[0].error).toEqual(new Error('Canvas conversion failed'));
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Canvas download failed, trying fetch:',
+      result.errors[0].error,
+    );
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a fetch failure before opening the image in a new tab', async () => {
+    const fetchError = new Error('CORS blocked');
+    const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockRejectedValue(fetchError);
+    global.fetch = fetchMock;
+
+    const result = await downloadImage('https://example.com/photo.jpg', 'photo.jpg');
+
+    expect(result).toEqual({
+      method: 'open-tab',
+      errors: [{ method: 'fetch', fallbackMethod: 'open-tab', error: fetchError }],
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'Fetch download failed, using fallback:',
+      fetchError,
+    );
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    const fallbackLink = clickSpy.mock.contexts[0] as HTMLAnchorElement;
+    expect(fallbackLink.href).toBe('https://example.com/photo.jpg');
+    expect(fallbackLink.download).toBe('photo.jpg');
+    expect(fallbackLink.target).toBe('_blank');
+    expect(fallbackLink.rel).toBe('noopener noreferrer');
+  });
+});

--- a/src/utils/downloadImage.ts
+++ b/src/utils/downloadImage.ts
@@ -1,3 +1,31 @@
+export type DownloadImageMethod = 'canvas' | 'fetch' | 'open-tab';
+
+export type DownloadImageError =
+  | {
+      method: 'canvas';
+      fallbackMethod: 'fetch';
+      error: unknown;
+    }
+  | {
+      method: 'fetch';
+      fallbackMethod: 'open-tab';
+      error: unknown;
+    };
+
+export type DownloadImageResult = {
+  method: DownloadImageMethod;
+  errors: DownloadImageError[];
+};
+
+const reportDownloadError = (
+  errors: DownloadImageError[],
+  error: DownloadImageError,
+  message: string,
+) => {
+  errors.push(error);
+  console.warn(message, error.error);
+};
+
 /**
  * Downloads an image using multiple fallback methods to handle CORS restrictions
  * @param imageSrc - The source URL of the image to download
@@ -8,7 +36,9 @@ export const downloadImage = async (
   imageSrc: string,
   filename: string,
   imageElement?: HTMLImageElement | null,
-): Promise<void> => {
+): Promise<DownloadImageResult> => {
+  const errors: DownloadImageError[] = [];
+
   // Method 1: Try using canvas (works for same-origin images, even without CORS headers)
   // This works because the image is already loaded in the browser
   if (imageElement && imageElement.complete) {
@@ -28,20 +58,24 @@ export const downloadImage = async (
         canvas.toBlob(resolve, 'image/png');
       });
 
-      if (blob) {
-        const url = window.URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = filename;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        window.URL.revokeObjectURL(url);
-        return;
-      }
+      if (!blob) throw new Error('Canvas conversion failed');
+
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+      return { method: 'canvas', errors };
     } catch (error) {
       // Canvas method failed (likely CORS issue with cross-origin image), try fetch
-      console.warn('Canvas download failed, trying fetch:', error);
+      reportDownloadError(
+        errors,
+        { method: 'canvas', fallbackMethod: 'fetch', error },
+        'Canvas download failed, trying fetch:',
+      );
     }
   }
 
@@ -59,10 +93,14 @@ export const downloadImage = async (
     link.click();
     document.body.removeChild(link);
     window.URL.revokeObjectURL(url);
-    return;
+    return { method: 'fetch', errors };
   } catch (error) {
     // Fetch failed (likely CORS issue), try fallback
-    console.warn('Fetch download failed, using fallback:', error);
+    reportDownloadError(
+      errors,
+      { method: 'fetch', fallbackMethod: 'open-tab', error },
+      'Fetch download failed, using fallback:',
+    );
   }
 
   // Method 3: Fallback - open in new tab (download attribute won't work for cross-origin)
@@ -76,4 +114,5 @@ export const downloadImage = async (
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+  return { method: 'open-tab', errors };
 };


### PR DESCRIPTION
## Summary
- Add a typed `DownloadImageResult` for `downloadImage`, including the method used and failed fallback attempts.
- Add an optional `onDownloadFallback` prop to `PhotoViewer` that fires when a download method has to fall back after canvas or fetch fails.
- Add regression coverage for the canvas/fetch/open-tab fallback chain, `toBlob(null)`, and the PhotoViewer callback threading.
- Document the new callback and add a minor changeset for the additive public API.

## Why
Fixes #33.

Before this change, canvas and fetch failures were only written to `console.warn`, and consumers could not inspect the fallback path or show their own toast/message. The callback is named as a fallback signal because a fallback can still end in a successful download, such as canvas failing and fetch succeeding.

## Verification
- `corepack yarn install --immutable`
- `corepack yarn test src/components/photo-viewer/__tests__/PhotoViewer.test.tsx --runInBand`
- `corepack yarn test src/utils/__tests__/downloadImage.test.ts --runInBand`
- `corepack yarn format:check`
- `corepack yarn lint` (0 errors; existing coverage report / Storybook warnings remain)
- `corepack yarn exec tsc --noEmit`
- `corepack yarn test --runInBand`
- `corepack yarn coverage --runInBand`
- `corepack yarn build`
- `npm exec --yes @arethetypeswrong/cli -- --pack .`
- `git diff --check`

## Notes
Kept this scoped to download fallback reporting. The existing fallback behavior is preserved when no callback is provided.
