### PR TITLE
ci: deploy to Vercel only from main

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,13 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "installCommand": "yarn install",
   "buildCommand": "yarn build:vercel",
-  "outputDirectory": "storybook-static"
+  "outputDirectory": "storybook-static",
+  "git": {
+    "deploymentEnabled": {
+      "**": false,
+      "main": true
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Restricts Vercel git deployments to the production branch (`main`). Fork PRs can't be built by Vercel without manual authorization, so every branch/PR currently reports the `Vercel` check as a failure even when CI is green (see #42, #43, #44). Limiting deployments to `main` stops non-main branches from triggering Vercel at all.

## Changes
- Add `git.deploymentEnabled` to `vercel.json`: `"**": false` disables every branch, `"main": true` re-enables only production. `**` (not `*`) is used so it matches branch names containing slashes (e.g. `ci/bundle-size-limit`).
- Add the `$schema` reference for editor validation.