### PR TITLE
fix: portal PhotoViewer and hide background content

### DIFF
--- a/.changeset/calm-doors-wait.md
+++ b/.changeset/calm-doors-wait.md
@@ -1,0 +1,7 @@
+---
+'zimme-zoom': patch
+---
+
+Render PhotoViewer through a document-body portal and hide background content while it is open.
+
+The viewer now avoids ancestor stacking contexts, removes background content from the accessibility tree with `inert` and `aria-hidden`, restores focus after the background is re-enabled, and keeps late-mounted body children hidden until the viewer closes.

--- a/src/components/photo-viewer/PhotoViewer.tsx
+++ b/src/components/photo-viewer/PhotoViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import Navigation from './Navigation';
 import PhotoViewerImage from './PhotoViewerImage';
 import type { PhotoViewerLabels, PhotoViewerSettings } from './types';
@@ -9,6 +10,7 @@ import {
   EMPTY_PHOTO_VIEWER_SETTINGS,
 } from '../../utils/photo-viewer/constants';
 import { useBodyScrollLock } from '../../hooks/photo-viewer/useBodyScrollLock';
+import { useBackgroundInert } from '../../hooks/photo-viewer/useBackgroundInert';
 import { useClickOutsideToClose } from '../../hooks/photo-viewer/useClickOutsideToClose';
 import { useFocusTrap } from '../../hooks/photo-viewer/useFocusTrap';
 import { useImageNavigation } from '../../hooks/photo-viewer/useImageNavigation';
@@ -115,6 +117,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const [showOverlay, setShowOverlay] = useState(
     () => showOverlayByDefault && !!selectedImage?.svgOverlay,
   );
+  const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     setShowOverlay(showOverlayByDefault && !!selectedImage?.svgOverlay);
@@ -198,8 +201,13 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     onZoomTo: zoomTo,
   });
 
+  // Hooks run above the early return below, so a mounted-but-closed viewer
+  // would otherwise keep global modal behavior active while rendering nothing.
+  const isOpen = !!selectedImage && !!currentImage;
+  const dialogReady = isOpen && !!portalRoot;
+
   useKeyboardShortcuts({
-    enabled: keyboardInteraction,
+    enabled: dialogReady && keyboardInteraction,
     handlers: {
       onClose,
       onZoomIn: handleZoomIn,
@@ -211,16 +219,22 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     },
   });
 
-  useClickOutsideToClose({ enabled: clickOutsideToExit, onClose });
+  useClickOutsideToClose({ enabled: dialogReady && clickOutsideToExit, onClose });
 
-  // Hooks run above the early return below, so a mounted-but-closed viewer
-  // would otherwise trap focus and lock body scroll while rendering nothing.
-  const isOpen = !!selectedImage && !!currentImage;
+  useEffect(() => {
+    if (!isOpen) {
+      setPortalRoot(null);
+      return;
+    }
 
-  useFocusTrap({ enabled: isOpen, containerRef });
-  useBodyScrollLock({ enabled: isOpen });
+    setPortalRoot(document.body);
+  }, [isOpen]);
 
-  if (!selectedImage || !currentImage) return null;
+  useFocusTrap({ enabled: dialogReady, containerRef });
+  useBodyScrollLock({ enabled: dialogReady });
+  useBackgroundInert({ enabled: dialogReady, dialogRef: containerRef });
+
+  if (!selectedImage || !currentImage || !portalRoot) return null;
 
   const imageContainerStyle: React.CSSProperties = {
     ...imageContainerBaseStyle,
@@ -230,7 +244,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
   const hasMultipleImages = images.length > 1;
   const canReset = zoom !== 1 || rotationCount % 4 !== 0;
 
-  return (
+  return createPortal(
     <div
       ref={containerRef}
       className="photo-viewer"
@@ -284,6 +298,7 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
       </div>
 
       {keyframesStyle}
-    </div>
+    </div>,
+    portalRoot,
   );
 };

--- a/src/components/photo-viewer/PhotoViewer.tsx
+++ b/src/components/photo-viewer/PhotoViewer.tsx
@@ -230,9 +230,9 @@ export const PhotoViewer: React.FC<PhotoViewerProps> = ({
     setPortalRoot(document.body);
   }, [isOpen]);
 
+  useBackgroundInert({ enabled: dialogReady, dialogRef: containerRef });
   useFocusTrap({ enabled: dialogReady, containerRef });
   useBodyScrollLock({ enabled: dialogReady });
-  useBackgroundInert({ enabled: dialogReady, dialogRef: containerRef });
 
   if (!selectedImage || !currentImage || !portalRoot) return null;
 

--- a/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
+++ b/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
@@ -222,6 +222,8 @@ describe('PhotoViewer accessibility', () => {
         </>,
       );
 
+      // The background accessibility tests assert that role queries cannot see
+      // this button while its owner tree is aria-hidden.
       const outside = screen.getByTestId('outside');
       const dialog = screen.getByRole('dialog');
 
@@ -240,6 +242,8 @@ describe('PhotoViewer accessibility', () => {
         </>,
       );
 
+      // The background accessibility tests assert that role queries cannot see
+      // this button while its owner tree is aria-hidden.
       screen.getByTestId('outside').focus();
 
       expect(screen.getByRole('dialog')).toHaveFocus();
@@ -313,6 +317,32 @@ describe('PhotoViewer accessibility', () => {
       await user.keyboard('{Escape}');
 
       expect(trigger).toHaveFocus();
+    });
+
+    it('restores focus after background inert is removed', async () => {
+      const user = userEvent.setup();
+      const nativeFocus = HTMLElement.prototype.focus;
+      const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus').mockImplementation(function focus(
+        this: HTMLElement,
+        options?: FocusOptions,
+      ) {
+        if (this.closest('[inert]')) return;
+        nativeFocus.call(this, options);
+      });
+
+      try {
+        render(<Harness />);
+        const trigger = screen.getByRole('button', { name: 'Open' });
+
+        await user.click(trigger);
+        expect(screen.getByRole('dialog')).toHaveFocus();
+
+        await user.keyboard('{Escape}');
+
+        await waitFor(() => expect(trigger).toHaveFocus());
+      } finally {
+        focusSpy.mockRestore();
+      }
     });
 
     it('restores focus under StrictMode, whose setup/cleanup/setup remount must not discard the opener', async () => {
@@ -461,20 +491,70 @@ describe('PhotoViewer accessibility', () => {
 
       rerender(<PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />);
 
-      expect(root).toHaveAttribute('inert', 'existing');
+      expect(root).toHaveAttribute('inert');
       expect(root).toHaveAttribute('aria-hidden', 'false');
 
       unmount();
       root.remove();
     });
 
-    it('keeps background content hidden until every open viewer closes', () => {
+    it('hides background children added while open and restores them on close', async () => {
+      const { rerender } = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+      const lateRoot = document.createElement('div');
+      const lateButton = document.createElement('button');
+      lateButton.textContent = 'late';
+      lateRoot.appendChild(lateButton);
+
+      document.body.appendChild(lateRoot);
+
+      await waitFor(() => expect(lateRoot).toHaveAttribute('inert'));
+      expect(lateRoot).toHaveAttribute('aria-hidden', 'true');
+      expect(screen.queryByRole('button', { name: 'late' })).not.toBeInTheDocument();
+
+      rerender(<PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />);
+
+      expect(lateRoot).not.toHaveAttribute('inert');
+      expect(lateRoot).not.toHaveAttribute('aria-hidden');
+      expect(screen.getByRole('button', { name: 'late' })).toBeInTheDocument();
+
+      lateRoot.remove();
+    });
+
+    it('hides non-HTML background children', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      document.body.appendChild(svg);
+
+      const { unmount } = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+
+      expect(svg).toHaveAttribute('inert');
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+
+      unmount();
+
+      expect(svg).not.toHaveAttribute('inert');
+      expect(svg).not.toHaveAttribute('aria-hidden');
+      svg.remove();
+    });
+
+    it('keeps background content hidden until every open viewer closes', async () => {
       const first = render(
         <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
       );
       const second = render(
         <PhotoViewer selectedImage={images[1]} images={images} onClose={jest.fn()} />,
       );
+      await waitFor(() => expect(second.container).toHaveAttribute('inert'));
+
+      const dialogs = screen.getAllByRole('dialog');
+      expect(dialogs).toHaveLength(2);
+      for (const dialog of dialogs) {
+        expect(dialog).not.toHaveAttribute('inert');
+        expect(dialog).not.toHaveAttribute('aria-hidden');
+      }
 
       expect(first.container).toHaveAttribute('inert');
       expect(first.container).toHaveAttribute('aria-hidden', 'true');
@@ -504,6 +584,8 @@ describe('PhotoViewer accessibility', () => {
     });
 
     it('does not access document during server rendering', () => {
+      // renderToString never runs effects; this is only a cheap guard against
+      // accidental render-time or module-level DOM access.
       expect(() =>
         renderToString(
           <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,

--- a/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
+++ b/src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import React, { useState } from 'react';
+import { renderToString } from 'react-dom/server';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PhotoViewer } from '../PhotoViewer';
@@ -85,10 +86,8 @@ describe('PhotoViewer accessibility', () => {
     });
 
     it('brightens the control bar while focus is inside it', () => {
-      const { container } = render(
-        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
-      );
-      const nav = container.querySelector('.photo-viewer-navigation') as HTMLElement;
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />);
+      const nav = document.body.querySelector('.photo-viewer-navigation') as HTMLElement;
 
       expect(nav).toHaveStyle({ backgroundColor: 'rgba(0, 0, 0, 0.5)' });
 
@@ -218,12 +217,12 @@ describe('PhotoViewer accessibility', () => {
       const user = userEvent.setup();
       render(
         <>
-          <button>outside</button>
+          <button data-testid="outside">outside</button>
           <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />
         </>,
       );
 
-      const outside = screen.getByRole('button', { name: 'outside' });
+      const outside = screen.getByTestId('outside');
       const dialog = screen.getByRole('dialog');
 
       for (let i = 0; i < DEFAULT_CONTROL_NAMES.length + 2; i += 1) {
@@ -236,12 +235,12 @@ describe('PhotoViewer accessibility', () => {
     it('pulls focus back when something outside steals it', () => {
       render(
         <>
-          <button>outside</button>
+          <button data-testid="outside">outside</button>
           <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />
         </>,
       );
 
-      screen.getByRole('button', { name: 'outside' }).focus();
+      screen.getByTestId('outside').focus();
 
       expect(screen.getByRole('dialog')).toHaveFocus();
     });
@@ -405,6 +404,111 @@ describe('PhotoViewer accessibility', () => {
 
       second.unmount();
       expect(document.body.style.overflow).toBe('scroll');
+    });
+  });
+
+  describe('portal and background accessibility', () => {
+    it('renders the dialog into document.body instead of inside the owner tree', () => {
+      const { container } = render(
+        <div style={{ transform: 'translateZ(0)' }}>
+          <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />
+        </div>,
+      );
+
+      const dialog = screen.getByRole('dialog');
+
+      expect(dialog.parentElement).toBe(document.body);
+      expect(container).not.toContainElement(dialog);
+    });
+
+    it('hides background content while open and restores it when closed', () => {
+      const { container, rerender } = render(
+        <>
+          <button>outside</button>
+          <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />
+        </>,
+      );
+
+      expect(container).toHaveAttribute('inert');
+      expect(container).toHaveAttribute('aria-hidden', 'true');
+      expect(screen.queryByRole('button', { name: 'outside' })).not.toBeInTheDocument();
+
+      rerender(
+        <>
+          <button>outside</button>
+          <PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />
+        </>,
+      );
+
+      expect(container).not.toHaveAttribute('inert');
+      expect(container).not.toHaveAttribute('aria-hidden');
+      expect(screen.getByRole('button', { name: 'outside' })).toBeInTheDocument();
+    });
+
+    it('restores pre-existing background aria-hidden and inert attributes', () => {
+      const root = document.createElement('div');
+      root.setAttribute('aria-hidden', 'false');
+      root.setAttribute('inert', 'existing');
+      document.body.appendChild(root);
+
+      const { rerender, unmount } = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+        { container: root },
+      );
+
+      expect(root).toHaveAttribute('inert', '');
+      expect(root).toHaveAttribute('aria-hidden', 'true');
+
+      rerender(<PhotoViewer selectedImage={null} images={images} onClose={jest.fn()} />);
+
+      expect(root).toHaveAttribute('inert', 'existing');
+      expect(root).toHaveAttribute('aria-hidden', 'false');
+
+      unmount();
+      root.remove();
+    });
+
+    it('keeps background content hidden until every open viewer closes', () => {
+      const first = render(
+        <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+      );
+      const second = render(
+        <PhotoViewer selectedImage={images[1]} images={images} onClose={jest.fn()} />,
+      );
+
+      expect(first.container).toHaveAttribute('inert');
+      expect(first.container).toHaveAttribute('aria-hidden', 'true');
+
+      second.unmount();
+
+      expect(first.container).toHaveAttribute('inert');
+      expect(first.container).toHaveAttribute('aria-hidden', 'true');
+
+      first.unmount();
+
+      expect(first.container).not.toHaveAttribute('inert');
+      expect(first.container).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('keeps click outside close working after the dialog moves to a portal', async () => {
+      const user = userEvent.setup();
+      const onClose = jest.fn();
+
+      render(<PhotoViewer selectedImage={images[0]} images={images} onClose={onClose} />);
+
+      await user.click(screen.getByAltText('First image'));
+      expect(onClose).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole('dialog'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not access document during server rendering', () => {
+      expect(() =>
+        renderToString(
+          <PhotoViewer selectedImage={images[0]} images={images} onClose={jest.fn()} />,
+        ),
+      ).not.toThrow();
     });
   });
 });

--- a/src/hooks/photo-viewer/useBackgroundInert.ts
+++ b/src/hooks/photo-viewer/useBackgroundInert.ts
@@ -1,0 +1,86 @@
+import { useEffect } from 'react';
+
+type InertElement = HTMLElement & { inert?: boolean };
+
+type HiddenSibling = {
+  element: HTMLElement;
+  inert: string | null;
+  ariaHidden: string | null;
+  inertProperty?: boolean;
+  count: number;
+};
+
+const hiddenSiblings = new Map<HTMLElement, HiddenSibling>();
+
+function getBackgroundSiblings(dialog: HTMLElement): HTMLElement[] {
+  return Array.from(document.body.children).filter(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && child !== dialog && !child.contains(dialog),
+  );
+}
+
+export function useBackgroundInert({
+  enabled,
+  dialogRef,
+}: {
+  enabled: boolean;
+  dialogRef: React.RefObject<HTMLElement | null>;
+}): void {
+  useEffect(() => {
+    if (!enabled) return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const siblings = getBackgroundSiblings(dialog);
+
+    for (const element of siblings) {
+      const existing = hiddenSiblings.get(element);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        hiddenSiblings.set(element, {
+          element,
+          inert: element.getAttribute('inert'),
+          ariaHidden: element.getAttribute('aria-hidden'),
+          inertProperty: 'inert' in element ? Boolean((element as InertElement).inert) : undefined,
+          count: 1,
+        });
+      }
+
+      element.setAttribute('inert', '');
+      element.setAttribute('aria-hidden', 'true');
+      if ('inert' in element) {
+        (element as InertElement).inert = true;
+      }
+    }
+
+    return () => {
+      for (const element of siblings) {
+        const hidden = hiddenSiblings.get(element);
+        if (!hidden) continue;
+
+        hidden.count -= 1;
+        if (hidden.count > 0) continue;
+
+        const { inert, ariaHidden, inertProperty } = hidden;
+        if (inert === null) {
+          element.removeAttribute('inert');
+        } else {
+          element.setAttribute('inert', inert);
+        }
+
+        if (ariaHidden === null) {
+          element.removeAttribute('aria-hidden');
+        } else {
+          element.setAttribute('aria-hidden', ariaHidden);
+        }
+
+        if (inertProperty !== undefined) {
+          (element as InertElement).inert = inertProperty;
+        }
+
+        hiddenSiblings.delete(element);
+      }
+    };
+  }, [dialogRef, enabled]);
+}

--- a/src/hooks/photo-viewer/useBackgroundInert.ts
+++ b/src/hooks/photo-viewer/useBackgroundInert.ts
@@ -1,22 +1,62 @@
 import { useEffect } from 'react';
 
-type InertElement = HTMLElement & { inert?: boolean };
+type InertElement = Element & { inert?: boolean };
 
 type HiddenSibling = {
-  element: HTMLElement;
-  inert: string | null;
+  inert: boolean;
   ariaHidden: string | null;
-  inertProperty?: boolean;
   count: number;
 };
 
-const hiddenSiblings = new Map<HTMLElement, HiddenSibling>();
+const hiddenSiblings = new WeakMap<Element, HiddenSibling>();
 
-function getBackgroundSiblings(dialog: HTMLElement): HTMLElement[] {
-  return Array.from(document.body.children).filter(
-    (child): child is HTMLElement =>
-      child instanceof HTMLElement && child !== dialog && !child.contains(dialog),
+function isBackgroundSibling(element: Element, dialog: HTMLElement): boolean {
+  return (
+    element !== dialog &&
+    !element.contains(dialog) &&
+    !(element.getAttribute('role') === 'dialog' && element.getAttribute('aria-modal') === 'true')
   );
+}
+
+function hideSibling(element: Element): void {
+  const existing = hiddenSiblings.get(element);
+  if (existing) {
+    existing.count += 1;
+  } else {
+    hiddenSiblings.set(element, {
+      inert: element.hasAttribute('inert'),
+      ariaHidden: element.getAttribute('aria-hidden'),
+      count: 1,
+    });
+  }
+
+  element.setAttribute('inert', '');
+  element.setAttribute('aria-hidden', 'true');
+  if ('inert' in element) {
+    (element as InertElement).inert = true;
+  }
+}
+
+function restoreSibling(element: Element): void {
+  const hidden = hiddenSiblings.get(element);
+  if (!hidden) return;
+
+  hidden.count -= 1;
+  if (hidden.count > 0) return;
+
+  if (hidden.inert) {
+    element.setAttribute('inert', '');
+  } else {
+    element.removeAttribute('inert');
+  }
+
+  if (hidden.ariaHidden === null) {
+    element.removeAttribute('aria-hidden');
+  } else {
+    element.setAttribute('aria-hidden', hidden.ariaHidden);
+  }
+
+  hiddenSiblings.delete(element);
 }
 
 export function useBackgroundInert({
@@ -31,55 +71,30 @@ export function useBackgroundInert({
     const dialog = dialogRef.current;
     if (!dialog) return;
 
-    const siblings = getBackgroundSiblings(dialog);
+    const siblings = new Set<Element>();
+    const hideBackgroundSibling = (element: Element) => {
+      if (!isBackgroundSibling(element, dialog) || siblings.has(element)) return;
+      siblings.add(element);
+      hideSibling(element);
+    };
 
-    for (const element of siblings) {
-      const existing = hiddenSiblings.get(element);
-      if (existing) {
-        existing.count += 1;
-      } else {
-        hiddenSiblings.set(element, {
-          element,
-          inert: element.getAttribute('inert'),
-          ariaHidden: element.getAttribute('aria-hidden'),
-          inertProperty: 'inert' in element ? Boolean((element as InertElement).inert) : undefined,
-          count: 1,
-        });
-      }
+    Array.from(document.body.children).forEach(hideBackgroundSibling);
 
-      element.setAttribute('inert', '');
-      element.setAttribute('aria-hidden', 'true');
-      if ('inert' in element) {
-        (element as InertElement).inert = true;
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            hideBackgroundSibling(node as Element);
+          }
+        }
       }
-    }
+    });
+    observer.observe(document.body, { childList: true });
 
     return () => {
+      observer.disconnect();
       for (const element of siblings) {
-        const hidden = hiddenSiblings.get(element);
-        if (!hidden) continue;
-
-        hidden.count -= 1;
-        if (hidden.count > 0) continue;
-
-        const { inert, ariaHidden, inertProperty } = hidden;
-        if (inert === null) {
-          element.removeAttribute('inert');
-        } else {
-          element.setAttribute('inert', inert);
-        }
-
-        if (ariaHidden === null) {
-          element.removeAttribute('aria-hidden');
-        } else {
-          element.setAttribute('aria-hidden', ariaHidden);
-        }
-
-        if (inertProperty !== undefined) {
-          (element as InertElement).inert = inertProperty;
-        }
-
-        hiddenSiblings.delete(element);
+        restoreSibling(element);
       }
     };
   }, [dialogRef, enabled]);


### PR DESCRIPTION
## Summary
- render PhotoViewer into `document.body` with a portal once the client document is available
- hide body siblings with `inert` and `aria-hidden` while the dialog is open, then restore the previous values
- gate modal-only global handlers until the portal dialog is mounted
- add regression coverage for portal placement, background hiding/restoration, multiple open viewers, click-outside behavior, and server rendering

## Why
Fixes #38.

The existing dialog used `aria-modal="true"` and a focus trap, but it still rendered in place. That left background content visible to screen reader virtual cursor navigation in some browser/AT combinations and made the viewer vulnerable to ancestor stacking contexts.

## Verification
- `yarn test src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx --runInBand`
- `yarn test src/components/photo-viewer/__tests__/PhotoViewer.test.tsx src/components/photo-viewer/__tests__/PhotoViewer.a11y.test.tsx --runInBand`
- `yarn test --runInBand`
- `yarn lint`
- `yarn format:check`
- `yarn build`
- `git diff --check`

## Notes
The portal root is set inside an effect so server rendering does not touch `document`. The background hiding logic uses reference counting so one viewer cannot restore background content while another viewer is still open.
