### PR TITLE
docs: document the code review process in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,71 @@
 # Contributing to zimme-zoom
 
-Thank you for your interest in contributing to zimme-zoom! This document provides guidelines and instructions for contributing.
+Thanks for your interest in contributing to zimme-zoom!
 
 ## Getting Started
 
-1. Fork the repository
-2. Clone your fork: `git clone https://github.com/your-username/zimme-zoom.git`
+1. Fork and clone the repository
+2. Enable Corepack so the pinned Yarn 4 version is used: `corepack enable`
 3. Install dependencies: `yarn install`
-4. Create a new branch: `git checkout -b feature/your-feature-name`
+4. Create a branch: `git checkout -b feature/your-feature-name`
 
 ## Development
 
-### Running Storybook
-
-To see your changes in action, run Storybook:
-
 ```bash
-yarn storybook
+yarn storybook   # see your changes in action
+yarn test        # run the test suite
+yarn lint        # lint
+yarn format      # format
+yarn build       # build the library
 ```
 
-### Building
-
-Build the library:
-
-```bash
-yarn build
-```
-
-### Code Style
-
-- Follow the existing code style
-- Run the linter: `yarn lint`
-- Format code: `yarn format`
+Husky runs `lint-staged` and the tests on commit, and lints the message with commitlint.
+Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/), for example `fix(PhotoViewer): restore focus to the opener`.
 
 ## Making Changes
 
-1. Make your changes in the `src/` directory
-2. Add or update stories in `src/stories/` if needed
-3. Test your changes in Storybook
-4. Ensure the build passes: `yarn build`
+1. Make your changes in `src/`
+2. Add or update tests, and stories in `src/stories/` if needed
+3. Ensure everything passes: `yarn lint && yarn test && yarn build`
+4. Add a changeset if the published package is affected: `yarn changeset`
+   (tooling, CI, and docs-only changes do not need one)
 
 ## Submitting Changes
 
-1. Commit your changes with a clear message
-2. Push to your fork
-3. Create a Pull Request with a description of your changes
+Push to your fork and open a Pull Request describing what changed and why.
+Keep it focused on one thing, include tests or a story for new behavior, add a screenshot for visual changes, and make sure CI is green before asking for review.
+
+## Review Process
+
+A maintainer reviews the PR, you address the feedback, and it is merged as a squash merge.
+
+### Keep review fixes as separate commits
+
+**Do not squash, amend, or rebase while addressing review feedback.**
+Push each round of fixes as new commits.
+Rewriting history breaks the reviewer's "Changes since last review" view and can orphan their inline comments.
+Messy commits are fine, since the PR is squash merged and the branch history never reaches `main`.
+
+### Responding to review comments
+
+**Every comment must end up either resolved or answered.
+Never leave one silently untouched.**
+
+- **Applied as suggested:** push the fix and resolve the conversation.
+- **Solved differently:** reply explaining what you did instead and why, then resolve.
+  Never resolve silently, the reviewer needs to know their suggestion is not what landed.
+- **Not addressed:** leave it **unresolved** and reply with the reason (out of scope, disagreement, or deferred with a linked issue).
+- **Not understood:** ask on the thread and leave it unresolved.
+
+A resolved thread means "settled", so resolving without explanation breaks that for everyone reading later.
+When everything is resolved or answered, re-request review with a short summary of what changed.
+
+### For reviewers
+
+Mark optional feedback with `nit:` or `suggestion:` so authors know what is blocking, and do not resolve the author's threads for them.
 
 ## Reporting Issues
 
-If you find a bug or have a feature request, please open an issue on GitHub with:
-
-- A clear description
-- Steps to reproduce (for bugs)
-- Expected vs actual behavior
-- Any relevant code examples
-
-## Questions?
-
-Feel free to open an issue for any questions or discussions about the project.
+Open an issue with a clear description, steps to reproduce, expected vs actual behavior, and any relevant code.
 
 Thank you for contributing! 🎉


### PR DESCRIPTION
## Summary

Adds a Review Process section to `CONTRIBUTING.md` describing how review feedback should be handled, and refreshes the setup and workflow steps so they match the current toolchain (Corepack + Yarn 4, Husky/commitlint, Changesets).

## Changes

- Require every review comment to end up either resolved or answered, with four explicit cases: applied as suggested, solved differently, not addressed, not understood
- Require a visible reply whenever the outcome differs from the reviewer's suggestion, and leaving the thread unresolved when nothing was done
- Forbid squashing, amending, or rebasing while addressing feedback, so the reviewer keeps a usable "Changes since last review" view and inline comments are not orphaned
- Add reviewer-side guidance (`nit:`/`suggestion:` severity prefixes, don't resolve the author's threads)
- Document Corepack and Yarn 4 setup, `yarn test`, Conventional Commits, and when a changeset is required
- Condense the existing sections so the file stays short